### PR TITLE
refactor: reorganize IA with sidebar steps and tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,4 @@
 ## [Unreleased]
 - Introduced streamlined theme configuration and startup header with quick guide for the 経営計画アプリ UI.
 - Applied container-based layout dividers and standardized table widths for improved readability.
+- Reorganized the layout IA with sidebar steps, tabbed content areas, and a validation status strip.


### PR DESCRIPTION
## Summary
- add sidebar navigation helper with step radio and contextual tips along with a reusable status strip placeholder
- wrap primary outputs into the new サマリー/詳細KPI/チャート/感度分析/ログ tabs while preserving existing computations
- extract the scenario editor/export logic into helper functions for reuse inside the 詳細KPI tab layout

## Testing
- python -m py_compile app.py

------
https://chatgpt.com/codex/tasks/task_e_68ce366f5fdc8323858265a978b4f5d4