### PR TITLE
feat(kpi): metrics & standardized altair charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,4 @@
 - Introduced streamlined theme configuration and startup header with quick guide for the 経営計画アプリ UI.
 - Applied container-based layout dividers and standardized table widths for improved readability.
 - Reorganized the layout IA with sidebar steps, tabbed content areas, and a validation status strip.
+- Added KPI delta cards, Altair-driven standard charts, and inline KPI drill-down mini visualizations.

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ matplotlib>=3.9.0; python_version >= '3.13'
 # pure-Python（wheel不要）
 openpyxl>=3.1.2
 plotly>=5.24.0
+altair>=5.2.0


### PR DESCRIPTION
## Summary
- add session-aware KPI cards with FCF and delta tracking on the summary tab
- replace the cost breakdown plot with Altair line, bar, and area charts for interactive exploration
- pair the detailed KPI table with inline Altair mini-charts and record the Altair dependency

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68ce909d0e2883238818fe801da09ce2