### PR TITLE
feat(what-if): sensitivity sliders and A/B/C scenarios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@
 - Applied container-based layout dividers and standardized table widths for improved readability.
 - Reorganized the layout IA with sidebar steps, tabbed content areas, and a validation status strip.
 - Added KPI delta cards, Altair-driven standard charts, and inline KPI drill-down mini visualizations.
+- Added sensitivity what-if controls with A/B/C scenario presets, KPI deltas, and in-tab comparison mini charts.


### PR DESCRIPTION
## Summary
- add helper utilities for sensitivity scenarios, plan recomputation, and plan input conversion
- extend the 感度分析 tab with what-if sliders, scenario presets, KPI deltas, and compact comparison charts
- document the sensitivity what-if experience in the changelog

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68ce93c0d7908323b0f62285debaa545