### PR TITLE
style(tables): unified column_config & sizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@
 - Reorganized the layout IA with sidebar steps, tabbed content areas, and a validation status strip.
 - Added KPI delta cards, Altair-driven standard charts, and inline KPI drill-down mini visualizations.
 - Added sensitivity what-if controls with A/B/C scenario presets, KPI deltas, and in-tab comparison mini charts.
+- Standardized table rendering with column_config-driven currency/percent styling, sticky headers, and responsive heights.


### PR DESCRIPTION
## Summary
- add shared helpers to sanitize numeric values and generate column_config with sticky headers
- convert scenario, KPI, and cost tables to numeric outputs and standardize currency/percent formatting
- apply consistent sizing/height parameters across management, override preview, and anomaly tables

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68ce991910808323921424f683bb9b79