### PR TITLE
Refine app chrome and session management

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,7 +1,7 @@
 [theme]
-base="light"
-primaryColor="#2B6CB0"
-backgroundColor="#FFFFFF"
-secondaryBackgroundColor="#F7FAFC"
-textColor="#1A202C"
-font="sans serif"
+base = "system"
+primaryColor = "#1F4E79"
+backgroundColor = "#F7F9FB"
+secondaryBackgroundColor = "#FFFFFF"
+textColor = "#203040"
+font = "sans serif"

--- a/app.py
+++ b/app.py
@@ -1,5 +1,12 @@
 
 import streamlit as st
+
+st.set_page_config(
+    page_title="経営計画スタジオ",
+    page_icon="📊",
+    layout="wide",
+)
+
 import pandas as pd
 import numpy as np
 import io
@@ -15,11 +22,8 @@ from matplotlib.ticker import FuncFormatter
 from openpyxl.styles import Font, Alignment
 from openpyxl.utils import get_column_letter
 
-st.set_page_config(
-    page_title="経営計画アプリ",
-    page_icon="📊",
-    layout="wide",
-)
+from state import ensure_session_defaults, reset_app_state
+from ui.chrome import HeaderActions, render_app_footer, render_app_header, render_usage_guide_panel
 
 THEME_COLORS: Dict[str, str] = {
     "background": "#F7F9FB",
@@ -304,28 +308,23 @@ div[data-testid="stDataFrame"] table tbody tr:hover {{
 
 st.markdown(CUSTOM_STYLE, unsafe_allow_html=True)
 
+ensure_session_defaults()
+
 status_placeholder = st.empty()
 
-if "show_usage_guide" not in st.session_state:
-    st.session_state["show_usage_guide"] = False
+header_actions: HeaderActions = render_app_header(
+    title="経営計画スタジオ",
+    subtitle="入力→検証→分析→可視化→出力をスムーズに。初めてでも迷わない設計。",
+)
 
-with st.container():
-    header_cols = st.columns([4, 1], gap="large")
-    with header_cols[0]:
-        st.title("経営計画アプリ")
-        st.caption("入力→検証→分析→可視化→出力をスムーズに。初めてでも迷わない設計。")
-    with header_cols[1]:
-        if st.button("使い方ガイド", use_container_width=True):
-            st.session_state["show_usage_guide"] = not st.session_state["show_usage_guide"]
+if header_actions.reset_requested:
+    reset_app_state()
+    st.experimental_rerun()
 
-guide_placeholder = st.container()
-if st.session_state.get("show_usage_guide"):
-    with guide_placeholder.expander("3ステップ活用ガイド", expanded=True):
-        st.markdown(
-            "1. **入力を整える**: コントロールハブで売上・コストのレバーと会計年度、FTEを設定します。\n"
-            "2. **検証と分析**: シナリオ/感応度タブで前提を比較し、AIインサイトでチェックポイントを確認します。\n"
-            "3. **可視化と出力**: グラフや表で可視化し、エクスポートタブからExcelをダウンロードして共有します。"
-        )
+if header_actions.toggled_help:
+    st.session_state["show_usage_guide"] = not st.session_state.get("show_usage_guide", False)
+
+render_usage_guide_panel()
 
 with st.container():
     st.markdown(
@@ -3050,6 +3049,4 @@ with status_placeholder.container():
         unsafe_allow_html=True,
     )
 
-st.divider()
-
-st.caption("© 経営計画策定WEBアプリ（Streamlit版） | 表示単位と計算単位を分離し、丸めの影響を最小化しています。")
+render_app_footer()

--- a/state.py
+++ b/state.py
@@ -1,0 +1,95 @@
+"""Utilities for managing Streamlit session state defaults and resets."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Iterable, Mapping
+
+import pandas as pd
+import streamlit as st
+
+StateFactory = Callable[[], Any]
+TypeHint = type | tuple[type, ...] | None
+
+
+@dataclass(frozen=True)
+class StateSpec:
+    """Definition of a session state entry."""
+
+    default_factory: StateFactory
+    type_hint: TypeHint
+    description: str
+
+    def create_default(self) -> Any:
+        """Return a new default value for the state entry."""
+        return self.default_factory()
+
+    def is_valid(self, value: Any) -> bool:
+        """Check whether *value* matches the declared type hint."""
+        if self.type_hint is None:
+            return True
+        hints = self.type_hint if isinstance(self.type_hint, tuple) else (self.type_hint,)
+        return isinstance(value, hints)
+
+
+STATE_SPECS: Dict[str, StateSpec] = {
+    "show_usage_guide": StateSpec(lambda: False, bool, "ヘルプ表示トグル"),
+    "sensitivity_zoom_mode": StateSpec(lambda: False, bool, "感応度グラフ拡大モード"),
+    "sensitivity_current": StateSpec(dict, dict, "感応度ビュー設定"),
+    "kpi_history": StateSpec(dict, dict, "KPIメトリック履歴"),
+    "metrics_timeline": StateSpec(list, list, "KPI推移の履歴"),
+    "scenario_df": StateSpec(lambda: None, (pd.DataFrame, type(None)), "シナリオ設定データフレーム"),
+    "scenario_editor": StateSpec(dict, dict, "シナリオエディタ状態"),
+    "scenarios": StateSpec(list, (list, tuple, dict), "シナリオ保存データ"),
+    "overrides": StateSpec(dict, dict, "金額上書き値"),
+    "sidebar_step": StateSpec(lambda: "①データ入力", str, "サイドバーナビの選択ステップ"),
+    "last_updated_ts": StateSpec(lambda: "", str, "最終更新タイムスタンプ"),
+    "validation_status": StateSpec(lambda: "—", str, "検証ステータス表示"),
+    "what_if_presets": StateSpec(dict, dict, "What-ifプリセット"),
+    "what_if_scenarios": StateSpec(dict, dict, "What-ifシナリオ集合"),
+    "what_if_default_quantity": StateSpec(lambda: None, (float, int, type(None)), "数量の既定値"),
+    "what_if_default_customers": StateSpec(lambda: None, (float, int, type(None)), "顧客数の既定値"),
+    "what_if_product_share": StateSpec(lambda: 0.6, (float, int), "製品売上比率の初期値"),
+    "what_if_active": StateSpec(lambda: "A", str, "現在アクティブなWhat-ifシナリオ"),
+}
+
+
+def ensure_session_defaults(overrides: Mapping[str, Any] | None = None) -> None:
+    """Populate :mod:`st.session_state` with defaults and type-validate entries."""
+
+    overrides = overrides or {}
+    for key, spec in STATE_SPECS.items():
+        if key in overrides:
+            st.session_state[key] = overrides[key]
+            continue
+        if key not in st.session_state or not spec.is_valid(st.session_state[key]):
+            st.session_state[key] = spec.create_default()
+
+
+def reset_session_keys(keys: Iterable[str] | None = None) -> None:
+    """Reset selected state keys to their default values."""
+
+    target_keys = list(keys) if keys is not None else list(STATE_SPECS.keys())
+    for key in target_keys:
+        if key in STATE_SPECS:
+            st.session_state[key] = STATE_SPECS[key].create_default()
+        elif key in st.session_state:
+            del st.session_state[key]
+
+
+def reset_app_state(preserve: Iterable[str] | None = None) -> None:
+    """Clear the current session state and re-apply defaults."""
+
+    preserved = set(preserve or [])
+    for key in list(st.session_state.keys()):
+        if key not in preserved:
+            del st.session_state[key]
+    ensure_session_defaults()
+
+
+__all__ = [
+    "StateSpec",
+    "STATE_SPECS",
+    "ensure_session_defaults",
+    "reset_session_keys",
+    "reset_app_state",
+]

--- a/ui/chrome.py
+++ b/ui/chrome.py
@@ -1,0 +1,91 @@
+"""Shared UI chrome elements (header, footer, help tools)."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+import streamlit as st
+
+USAGE_GUIDE_TEXT = (
+    "1. **入力を整える**: コントロールハブで売上・コストのレバーと会計年度、FTEを設定します。\n"
+    "2. **検証と分析**: シナリオ/感応度タブで前提を比較し、AIインサイトでチェックポイントを確認します。\n"
+    "3. **可視化と出力**: グラフや表で可視化し、エクスポートタブからExcelをダウンロードして共有します。"
+)
+
+
+@dataclass(frozen=True)
+class HeaderActions:
+    """User interactions emitted from the global header."""
+
+    toggled_help: bool = False
+    reset_requested: bool = False
+
+
+def render_app_header(
+    *,
+    title: str,
+    subtitle: str,
+    help_key: str = "show_usage_guide",
+    help_button_label: str = "使い方ガイド",
+    reset_label: str = "Reset all",
+    show_reset: bool = True,
+    on_reset: Callable[[], None] | None = None,
+) -> HeaderActions:
+    """Render the global header with help and reset controls."""
+
+    toggled_help = False
+    reset_requested = False
+
+    with st.container():
+        columns = st.columns([4, 1, 1] if show_reset else [4, 1], gap="large")
+        with columns[0]:
+            st.title(title)
+            st.caption(subtitle)
+        help_col = columns[1]
+        with help_col:
+            if st.button(
+                help_button_label,
+                use_container_width=True,
+                key=f"{help_key}_toggle_button",
+            ):
+                toggled_help = True
+        if show_reset:
+            reset_col = columns[2]
+            with reset_col:
+                if st.button(
+                    reset_label,
+                    use_container_width=True,
+                    key="app_reset_all_button",
+                    help="入力値と分析結果を初期状態に戻します。",
+                ):
+                    reset_requested = True
+                    if on_reset is not None:
+                        on_reset()
+
+    return HeaderActions(toggled_help=toggled_help, reset_requested=reset_requested)
+
+
+def render_usage_guide_panel(help_key: str = "show_usage_guide") -> None:
+    """Display the collapsible usage guide when the toggle is active."""
+
+    placeholder = st.container()
+    if st.session_state.get(help_key):
+        with placeholder.expander("3ステップ活用ガイド", expanded=True):
+            st.markdown(USAGE_GUIDE_TEXT)
+
+
+def render_app_footer(
+    caption: str = "© 経営計画策定WEBアプリ（Streamlit版） | 表示単位と計算単位を分離し、丸めの影響を最小化しています。",
+) -> None:
+    """Render the global footer."""
+
+    st.divider()
+    st.caption(caption)
+
+
+__all__ = [
+    "HeaderActions",
+    "render_app_footer",
+    "render_app_header",
+    "render_usage_guide_panel",
+]


### PR DESCRIPTION
## Summary
- align the Streamlit theme with brand colours and force the app into wide layout with the new "経営計画スタジオ" title
- introduce `state.py` to initialise and reset Streamlit session state safely from a single place
- extract the shared header, help panel, and footer into `ui/chrome.py` and add a Reset all action that clears the session

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68ce9d82697883238ff2e8f516433864