### PR TITLE
Refactor into multi-page finance planning app

### DIFF
--- a/calc/__init__.py
+++ b/calc/__init__.py
@@ -1,0 +1,30 @@
+"""Calculation helpers for financial planning outputs."""
+
+from .pl import (
+    ITEMS,
+    ITEM_LABELS,
+    PlanConfig,
+    bisection_for_target_op,
+    build_scenario_dataframe,
+    compute,
+    compute_plan,
+    plan_from_models,
+    summarize_plan_metrics,
+)
+
+from .bs import generate_balance_sheet
+from .cf import generate_cash_flow
+
+__all__ = [
+    "ITEMS",
+    "ITEM_LABELS",
+    "PlanConfig",
+    "bisection_for_target_op",
+    "build_scenario_dataframe",
+    "compute",
+    "compute_plan",
+    "plan_from_models",
+    "summarize_plan_metrics",
+    "generate_balance_sheet",
+    "generate_cash_flow",
+]

--- a/calc/bs.py
+++ b/calc/bs.py
@@ -1,0 +1,49 @@
+"""Simple balance sheet estimation utilities."""
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Dict
+
+from models import CapexPlan, LoanSchedule, TaxPolicy
+
+
+def generate_balance_sheet(
+    pl_amounts: Dict[str, Decimal],
+    capex: CapexPlan,
+    loans: LoanSchedule,
+    tax: TaxPolicy,
+) -> Dict[str, Dict[str, Decimal]]:
+    """Return a lightweight balance sheet derived from P&L outputs."""
+
+    ordinary_income = Decimal(pl_amounts.get("ORD", Decimal("0")))
+    taxes = tax.effective_tax(ordinary_income)
+    retained = ordinary_income - taxes
+    if retained < 0:
+        retained = Decimal("0")
+
+    cash = retained
+    gross_capex = capex.total_investment()
+    accumulated_dep = capex.annual_depreciation()
+    net_pp_e = max(Decimal("0"), gross_capex - accumulated_dep)
+
+    assets_total = cash + net_pp_e
+
+    debt = loans.outstanding_principal()
+    equity = assets_total - debt
+
+    assets = {
+        "現金同等物": cash,
+        "有形固定資産": net_pp_e,
+    }
+    liabilities = {
+        "有利子負債": debt,
+        "純資産": equity,
+    }
+    totals = {
+        "assets": assets_total,
+        "liabilities": debt + equity,
+    }
+    return {"assets": assets, "liabilities": liabilities, "totals": totals}
+
+
+__all__ = ["generate_balance_sheet"]

--- a/calc/cf.py
+++ b/calc/cf.py
@@ -1,0 +1,36 @@
+"""Cash flow estimation utilities."""
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Dict
+
+from models import CapexPlan, LoanSchedule, TaxPolicy
+
+
+def generate_cash_flow(
+    pl_amounts: Dict[str, Decimal],
+    capex: CapexPlan,
+    loans: LoanSchedule,
+    tax: TaxPolicy,
+) -> Dict[str, Decimal]:
+    """Compute a simple cash flow statement using annual totals."""
+
+    ordinary_income = Decimal(pl_amounts.get("ORD", Decimal("0")))
+    depreciation = Decimal(pl_amounts.get("OPEX_DEP", Decimal("0")))
+    taxes = tax.effective_tax(ordinary_income)
+
+    operating_cf = ordinary_income + depreciation - taxes
+    investing_cf = -capex.total_investment()
+    financing_cf = -(loans.annual_interest())
+
+    net_cf = operating_cf + investing_cf + financing_cf
+
+    return {
+        "営業キャッシュフロー": operating_cf,
+        "投資キャッシュフロー": investing_cf,
+        "財務キャッシュフロー": financing_cf,
+        "キャッシュ増減": net_cf,
+    }
+
+
+__all__ = ["generate_cash_flow"]

--- a/calc/pl.py
+++ b/calc/pl.py
@@ -1,0 +1,445 @@
+"""P&L related calculations built on top of typed financial models."""
+from __future__ import annotations
+
+from decimal import Decimal, getcontext
+from typing import Dict, List, Tuple
+
+import pandas as pd
+
+from models import (
+    CapexPlan,
+    CostPlan,
+    LoanSchedule,
+    SalesPlan,
+    TaxPolicy,
+)
+
+getcontext().prec = 28
+
+ITEMS: List[Tuple[str, str, str]] = [
+    ("REV", "売上高", "売上"),
+    ("COGS_MAT", "外部仕入｜材料費", "外部仕入"),
+    ("COGS_LBR", "外部仕入｜労務費(外部)", "外部仕入"),
+    ("COGS_OUT_SRC", "外部仕入｜外注費(専属)", "外部仕入"),
+    ("COGS_OUT_CON", "外部仕入｜外注費(委託)", "外部仕入"),
+    ("COGS_OTH", "外部仕入｜その他諸経費", "外部仕入"),
+    ("COGS_TTL", "外部仕入｜計", "外部仕入"),
+    ("GROSS", "粗利(加工高)", "粗利"),
+    ("OPEX_H", "内部費用｜人件費", "内部費用"),
+    ("OPEX_K", "内部費用｜経費", "内部費用"),
+    ("OPEX_DEP", "内部費用｜減価償却費", "内部費用"),
+    ("OPEX_TTL", "内部費用｜計", "内部費用"),
+    ("OP", "営業利益", "損益"),
+    ("NOI_MISC", "営業外収益｜雑収入", "営業外"),
+    ("NOI_GRANT", "営業外収益｜補助金/給付金", "営業外"),
+    ("NOI_OTH", "営業外収益｜その他", "営業外"),
+    ("NOE_INT", "営業外費用｜支払利息", "営業外"),
+    ("NOE_OTH", "営業外費用｜雑損", "営業外"),
+    ("ORD", "経常利益", "損益"),
+    ("BE_SALES", "損益分岐点売上高", "KPI"),
+    ("PC_SALES", "一人当たり売上", "KPI"),
+    ("PC_GROSS", "一人当たり粗利", "KPI"),
+    ("PC_ORD", "一人当たり経常利益", "KPI"),
+    ("LDR", "労働分配率", "KPI"),
+]
+
+ITEM_LABELS = {code: label for code, label, _ in ITEMS}
+
+
+class PlanConfig:
+    """Holds calculation settings for the simplified contribution model."""
+
+    def __init__(self, base_sales: Decimal, fte: Decimal, unit: str) -> None:
+        self.base_sales = Decimal(base_sales)
+        self.fte = Decimal(fte if fte else Decimal("0"))
+        if self.fte <= 0:
+            self.fte = Decimal("0.0001")
+        self.unit = unit
+        self.items: Dict[str, Dict[str, object]] = {}
+
+    def set_rate(self, code: str, rate: Decimal, rate_base: str = "sales") -> None:
+        self.items[code] = {
+            "method": "rate",
+            "value": Decimal(rate),
+            "rate_base": rate_base,
+        }
+
+    def set_amount(self, code: str, amount: Decimal) -> None:
+        self.items[code] = {
+            "method": "amount",
+            "value": Decimal(amount),
+            "rate_base": "fixed",
+        }
+
+    def add_amount(self, code: str, amount: Decimal) -> None:
+        amount = Decimal(amount)
+        if code in self.items and self.items[code].get("method") == "amount":
+            self.items[code]["value"] = Decimal(self.items[code]["value"]) + amount
+        else:
+            self.set_amount(code, amount)
+
+    def clone(self) -> "PlanConfig":
+        cloned = PlanConfig(self.base_sales, self.fte, self.unit)
+        cloned.items = {k: v.copy() for k, v in self.items.items()}
+        return cloned
+
+
+COST_CODES = ["COGS_MAT", "COGS_LBR", "COGS_OUT_SRC", "COGS_OUT_CON", "COGS_OTH"]
+OPEX_CODES = ["OPEX_H", "OPEX_K", "OPEX_DEP"]
+NOI_CODES = ["NOI_MISC", "NOI_GRANT", "NOI_OTH"]
+NOE_CODES = ["NOE_INT", "NOE_OTH"]
+
+
+def plan_from_models(
+    sales: SalesPlan,
+    costs: CostPlan,
+    capex: CapexPlan,
+    loans: LoanSchedule,
+    tax: TaxPolicy,
+    *,
+    fte: Decimal,
+    unit: str,
+) -> PlanConfig:
+    """Build a :class:`PlanConfig` from typed models."""
+
+    # Tax policy is forwarded to downstream cash-flow logic; the P&L plan focuses on operating figures.
+    _ = tax
+
+    base_sales = sales.annual_total()
+    plan = PlanConfig(base_sales=base_sales, fte=fte, unit=unit)
+
+    for code, ratio in costs.variable_ratios.items():
+        plan.set_rate(code, Decimal(ratio), rate_base="sales")
+    for code, ratio in costs.gross_linked_ratios.items():
+        plan.set_rate(code, Decimal(ratio), rate_base="gross")
+    for code, amount in costs.fixed_costs.items():
+        plan.add_amount(code, Decimal(amount))
+    for code, amount in costs.non_operating_income.items():
+        plan.add_amount(code, Decimal(amount))
+    for code, amount in costs.non_operating_expenses.items():
+        plan.add_amount(code, Decimal(amount))
+
+    depreciation = capex.annual_depreciation()
+    if depreciation > 0:
+        plan.add_amount("OPEX_DEP", depreciation)
+
+    interest = loans.annual_interest()
+    if interest > 0:
+        plan.add_amount("NOE_INT", interest)
+
+    # The tax policy is not directly embedded here; downstream calculations use it.
+    return plan
+
+
+def _line_amount(
+    plan: PlanConfig,
+    code: str,
+    gross_guess: Decimal,
+    sales: Decimal,
+    amount_overrides: Dict[str, Decimal] | None,
+) -> Decimal:
+    if amount_overrides and code in amount_overrides:
+        return Decimal(amount_overrides[code])
+    cfg = plan.items.get(code)
+    if cfg is None:
+        return Decimal("0")
+    method = cfg.get("method")
+    value = Decimal(cfg.get("value", Decimal("0")))
+    base = str(cfg.get("rate_base", "sales"))
+    if method == "amount":
+        return value
+    if base == "sales":
+        return sales * value
+    if base == "gross":
+        return max(Decimal("0"), gross_guess) * value
+    if base == "fixed":
+        return value
+    return sales * value
+
+
+def compute(
+    plan: PlanConfig,
+    sales_override: Decimal | None = None,
+    amount_overrides: Dict[str, Decimal] | None = None,
+) -> Dict[str, Decimal]:
+    sales = Decimal(plan.base_sales if sales_override is None else sales_override)
+    amounts: Dict[str, Decimal] = {code: Decimal("0") for code, *_ in ITEMS}
+    amounts["REV"] = sales
+
+    gross_guess = sales
+    for _ in range(5):
+        cogs = sum(
+            max(Decimal("0"), _line_amount(plan, code, gross_guess, sales, amount_overrides))
+            for code in COST_CODES
+        )
+        new_gross = sales - cogs
+        if abs(new_gross - gross_guess) < Decimal("0.0001"):
+            gross_guess = new_gross
+            break
+        gross_guess = new_gross
+
+    cogs_total = Decimal("0")
+    for code in COST_CODES:
+        val = max(Decimal("0"), _line_amount(plan, code, gross_guess, sales, amount_overrides))
+        amounts[code] = val
+        cogs_total += val
+    amounts["COGS_TTL"] = cogs_total
+    amounts["GROSS"] = sales - cogs_total
+
+    opex_total = Decimal("0")
+    for code in OPEX_CODES:
+        val = max(Decimal("0"), _line_amount(plan, code, amounts["GROSS"], sales, amount_overrides))
+        amounts[code] = val
+        opex_total += val
+    amounts["OPEX_TTL"] = opex_total
+    amounts["OP"] = amounts["GROSS"] - amounts["OPEX_TTL"]
+
+    for code in NOI_CODES + NOE_CODES:
+        val = max(Decimal("0"), _line_amount(plan, code, amounts["GROSS"], sales, amount_overrides))
+        amounts[code] = val
+
+    amounts["ORD"] = amounts["OP"] + (
+        amounts["NOI_MISC"] + amounts["NOI_GRANT"] + amounts["NOI_OTH"]
+    ) - (amounts["NOE_INT"] + amounts["NOE_OTH"])
+
+    variable_cost = Decimal("0")
+    for code in COST_CODES + OPEX_CODES + NOI_CODES + NOE_CODES:
+        cfg = plan.items.get(code)
+        if cfg and cfg.get("method") == "rate":
+            base = str(cfg.get("rate_base", "sales"))
+            rate = Decimal(cfg.get("value", Decimal("0")))
+            if base == "gross":
+                gross_ratio = amounts["GROSS"] / sales if sales > 0 else Decimal("0")
+                variable_cost += sales * (rate * gross_ratio)
+            else:
+                variable_cost += sales * rate
+
+    fixed_cost = Decimal("0")
+    for code in COST_CODES + OPEX_CODES + NOI_CODES + NOE_CODES:
+        cfg = plan.items.get(code)
+        if cfg and cfg.get("method") == "amount":
+            fixed_cost += Decimal(cfg.get("value", Decimal("0")))
+        elif cfg and str(cfg.get("rate_base")) == "fixed":
+            fixed_cost += Decimal(cfg.get("value", Decimal("0")))
+
+    contribution_ratio = Decimal("1") - (variable_cost / sales if sales > 0 else Decimal("0"))
+    if contribution_ratio <= 0:
+        amounts["BE_SALES"] = Decimal("Infinity")
+    else:
+        amounts["BE_SALES"] = fixed_cost / contribution_ratio
+
+    fte = plan.fte if plan.fte > 0 else Decimal("1")
+    amounts["PC_SALES"] = amounts["REV"] / fte
+    amounts["PC_GROSS"] = amounts["GROSS"] / fte
+    amounts["PC_ORD"] = amounts["ORD"] / fte
+    amounts["LDR"] = (
+        amounts["OPEX_H"] / amounts["GROSS"] if amounts["GROSS"] > 0 else Decimal("NaN")
+    )
+
+    return amounts
+
+
+def compute_plan(plan: Dict[str, Decimal]) -> Dict[str, Decimal]:
+    sales = Decimal(plan.get("sales", Decimal("0")))
+    gp_rate = Decimal(plan.get("gp_rate", Decimal("0")))
+    gross = sales * gp_rate
+    opex_h = Decimal(plan.get("opex_h", Decimal("0")))
+    opex_fixed = Decimal(plan.get("opex_fixed", Decimal("0")))
+    opex_dep = Decimal(plan.get("opex_dep", Decimal("0")))
+    opex_oth = Decimal(plan.get("opex_oth", Decimal("0")))
+    op = gross - opex_h - opex_fixed - opex_dep - opex_oth
+    return {
+        "sales": sales,
+        "gp_rate": gp_rate,
+        "gross": gross,
+        "opex_h": opex_h,
+        "opex_fixed": opex_fixed,
+        "opex_dep": opex_dep,
+        "opex_oth": opex_oth,
+        "op": op,
+        "ord": op,
+    }
+
+
+def summarize_plan_metrics(amounts: Dict[str, Decimal]) -> Dict[str, Decimal]:
+    sales = Decimal(amounts.get("REV", Decimal("0")))
+    gross = Decimal(amounts.get("GROSS", Decimal("0")))
+    op = Decimal(amounts.get("OP", Decimal("0")))
+    ord_val = Decimal(amounts.get("ORD", Decimal("0")))
+    opex = Decimal(amounts.get("OPEX_TTL", Decimal("0")))
+    cogs = Decimal(amounts.get("COGS_TTL", sales - gross))
+
+    def safe_ratio(num: Decimal, den: Decimal) -> Decimal:
+        return num / den if den not in (Decimal("0"), Decimal("NaN")) else Decimal("NaN")
+
+    metrics = {
+        "sales": sales,
+        "gross": gross,
+        "op": op,
+        "ord": ord_val,
+        "gross_margin": safe_ratio(gross, sales),
+        "op_margin": safe_ratio(op, sales),
+        "ord_margin": safe_ratio(ord_val, sales),
+        "cogs_ratio": safe_ratio(cogs, sales),
+        "opex_ratio": safe_ratio(opex, sales),
+        "labor_ratio": safe_ratio(Decimal(amounts.get("OPEX_H", Decimal("0"))), gross),
+        "breakeven": Decimal(amounts.get("BE_SALES", Decimal("NaN"))),
+    }
+    return metrics
+
+
+def _ord_from(result: Dict[str, Decimal], nonop: Dict[str, Decimal]) -> Decimal:
+    noi = nonop.get("noi_misc", Decimal("0")) + nonop.get("noi_grant", Decimal("0"))
+    noe = nonop.get("noe_int", Decimal("0")) + nonop.get("noe_oth", Decimal("0"))
+    return result["op"] + noi - noe
+
+
+def _plan_with(plan: Dict[str, Decimal], **overrides: Decimal) -> Dict[str, Decimal]:
+    new_plan = plan.copy()
+    new_plan.update(overrides)
+    return new_plan
+
+
+def _line_items(result: Dict[str, Decimal], nonop: Dict[str, Decimal]) -> Dict[str, Decimal]:
+    rev = result["sales"]
+    gross = result["gross"]
+    cogs_total = rev - gross
+    opex_total = result["opex_fixed"] + result["opex_h"] + result["opex_dep"] + result["opex_oth"]
+    ord_value = _ord_from(result, nonop)
+    return {
+        "REV": rev,
+        "COGS_TTL": cogs_total,
+        "GROSS": gross,
+        "OPEX_H": result["opex_h"],
+        "OPEX_FIXED": result["opex_fixed"],
+        "OPEX_DEP": result["opex_dep"],
+        "OPEX_OTH": result["opex_oth"],
+        "OPEX_TTL": opex_total,
+        "OP": result["op"],
+        "NOI_MISC": nonop.get("noi_misc", Decimal("0")),
+        "NOI_GRANT": nonop.get("noi_grant", Decimal("0")),
+        "NOE_INT": nonop.get("noe_int", Decimal("0")),
+        "NOE_OTH": nonop.get("noe_oth", Decimal("0")),
+        "ORD": ord_value,
+    }
+
+
+def _required_sales_for_ord(target_ord: Decimal, plan: Dict[str, Decimal], nonop: Dict[str, Decimal]) -> Decimal:
+    gp = max(Decimal("1e-9"), Decimal(plan["gp_rate"]))
+    opex_total = plan["opex_fixed"] + plan["opex_h"] + plan["opex_dep"] + plan["opex_oth"]
+    noi = nonop.get("noi_misc", Decimal("0")) + nonop.get("noi_grant", Decimal("0"))
+    noe = nonop.get("noe_int", Decimal("0")) + nonop.get("noe_oth", Decimal("0"))
+    return (target_ord + opex_total - noi + noe) / gp
+
+
+def _be_sales(plan: Dict[str, Decimal], nonop: Dict[str, Decimal], *, mode: str = "OP") -> Decimal:
+    gp = max(Decimal("1e-9"), Decimal(plan["gp_rate"]))
+    opex_total = plan["opex_fixed"] + plan["opex_h"] + plan["opex_dep"] + plan["opex_oth"]
+    noi = nonop.get("noi_misc", Decimal("0")) + nonop.get("noi_grant", Decimal("0"))
+    noe = nonop.get("noe_int", Decimal("0")) + nonop.get("noe_oth", Decimal("0"))
+    if mode == "ORD":
+        return (opex_total - noi + noe) / gp
+    return opex_total / gp
+
+
+def build_scenario_dataframe(
+    base_plan: Dict[str, Decimal],
+    plan: Dict[str, Decimal],
+    nonop: Dict[str, Decimal] | None = None,
+    target_ord: Decimal = Decimal("50000000"),
+    be_mode: str = "OP",
+) -> pd.DataFrame:
+    nonop = {
+        "noi_misc": Decimal("0"),
+        "noi_grant": Decimal("0"),
+        "noe_int": Decimal("0"),
+        "noe_oth": Decimal("0"),
+    } if nonop is None else {k: Decimal(v) for k, v in nonop.items()}
+
+    result_target = compute_plan(plan)
+    col_target = _line_items(result_target, nonop)
+
+    def col_sales_scale(scale: Decimal) -> Dict[str, Decimal]:
+        scaled = _plan_with(plan, sales=plan["sales"] * scale)
+        return _line_items(compute_plan(scaled), nonop)
+
+    col_sales_up = col_sales_scale(Decimal("1.10"))
+    col_sales_dn5 = col_sales_scale(Decimal("0.95"))
+    col_sales_dn10 = col_sales_scale(Decimal("0.90"))
+
+    gp_up = _plan_with(plan, gp_rate=min(Decimal("1"), plan["gp_rate"] + Decimal("0.01")))
+    col_gp_up = _line_items(compute_plan(gp_up), nonop)
+
+    required_sales = max(Decimal("0"), _required_sales_for_ord(target_ord, plan, nonop))
+    plan_for_ord = _plan_with(plan, sales=required_sales)
+    col_ord = _line_items(compute_plan(plan_for_ord), nonop)
+
+    col_last = _line_items(compute_plan(base_plan), nonop)
+
+    be_sales = max(Decimal("0"), _be_sales(plan, nonop, mode=be_mode))
+    plan_be = _plan_with(plan, sales=be_sales)
+    col_be = _line_items(compute_plan(plan_be), nonop)
+
+    df = pd.DataFrame.from_dict(
+        {
+            "目標": col_target,
+            "売上高10%増": col_sales_up,
+            "売上高5%減": col_sales_dn5,
+            "売上高10%減": col_sales_dn10,
+            "粗利率+1pt": col_gp_up,
+            "経常利益5千万円": col_ord,
+            "昨年同一": col_last,
+            "損益分岐点売上高": col_be,
+        },
+        orient="index",
+    ).T
+    return df
+
+
+def bisection_for_target_op(
+    plan: PlanConfig,
+    target_op: Decimal,
+    s_low: Decimal,
+    s_high: Decimal,
+    *,
+    max_iter: int = 60,
+    eps: Decimal = Decimal("1000"),
+) -> Tuple[Decimal, Dict[str, Decimal]]:
+    def op_at(value: Decimal) -> Decimal:
+        return compute(plan, sales_override=value)["ORD"]
+
+    low = max(Decimal("0"), s_low)
+    high = max(s_low * Decimal("1.5"), s_high)
+    f_low = op_at(low)
+    f_high = op_at(high)
+    iterations = 0
+    while (f_low - target_op) * (f_high - target_op) > 0 and high < Decimal("1e13") and iterations < 40:
+        high = high * Decimal("1.6") if high > 0 else Decimal("1000000")
+        f_high = op_at(high)
+        iterations += 1
+
+    for _ in range(max_iter):
+        mid = (low + high) / Decimal("2")
+        f_mid = op_at(mid)
+        if abs(f_mid - target_op) <= eps:
+            return mid, compute(plan, sales_override=mid)
+        if (f_low - target_op) * (f_mid - target_op) <= 0:
+            high, f_high = mid, f_mid
+        else:
+            low, f_low = mid, f_mid
+
+    mid = (low + high) / Decimal("2")
+    return mid, compute(plan, sales_override=mid)
+
+
+__all__ = [
+    "ITEMS",
+    "ITEM_LABELS",
+    "PlanConfig",
+    "plan_from_models",
+    "compute",
+    "compute_plan",
+    "summarize_plan_metrics",
+    "build_scenario_dataframe",
+    "bisection_for_target_op",
+]

--- a/formatting.py
+++ b/formatting.py
@@ -1,0 +1,84 @@
+"""Helper utilities for formatting numeric outputs."""
+from __future__ import annotations
+
+from decimal import Decimal, ROUND_HALF_UP
+from typing import Mapping
+
+UNIT_FACTORS: Mapping[str, Decimal] = {
+    "百万円": Decimal("1000000"),
+    "千円": Decimal("1000"),
+    "円": Decimal("1"),
+}
+
+
+def to_decimal(value: object) -> Decimal:
+    if isinstance(value, Decimal):
+        return value
+    if value is None:
+        return Decimal("0")
+    return Decimal(str(value))
+
+
+def format_money(value: object, unit: str = "円") -> str:
+    try:
+        amount = to_decimal(value)
+    except Exception:
+        return "—"
+    factor = UNIT_FACTORS.get(unit, Decimal("1"))
+    if factor == 0:
+        factor = Decimal("1")
+    scaled = amount / factor
+    if scaled.is_nan() or scaled.is_infinite():
+        return "—"
+    quant = Decimal("1") if abs(scaled) >= 1 else Decimal("0.01")
+    scaled = scaled.quantize(quant, rounding=ROUND_HALF_UP)
+    if quant == Decimal("1"):
+        return f"¥{scaled:,.0f}"
+    return f"¥{scaled:,.2f}"
+
+
+def format_amount_with_unit(value: object, unit: str) -> str:
+    formatted = format_money(value, unit)
+    return formatted if formatted == "—" else f"{formatted} {unit}"
+
+
+def format_ratio(value: object) -> str:
+    try:
+        ratio = to_decimal(value)
+    except Exception:
+        return "—"
+    if ratio.is_nan() or ratio.is_infinite():
+        return "—"
+    return f"{ratio * Decimal('100'):.1f}%"
+
+
+def format_delta(value: object, unit: str) -> str:
+    try:
+        amount = to_decimal(value)
+    except Exception:
+        return "±0"
+    if amount == 0 or amount.is_nan() or amount.is_infinite():
+        return "±0"
+    sign = "+" if amount > 0 else "-"
+    return f"{sign}{format_amount_with_unit(abs(amount), unit)}"
+
+
+def format_ratio_delta(value: object) -> str:
+    try:
+        amount = to_decimal(value)
+    except Exception:
+        return "±0"
+    if amount == 0 or amount.is_nan() or amount.is_infinite():
+        return "±0"
+    return f"{amount * Decimal('100'):+.1f}pt"
+
+
+__all__ = [
+    "UNIT_FACTORS",
+    "format_money",
+    "format_amount_with_unit",
+    "format_ratio",
+    "format_delta",
+    "format_ratio_delta",
+    "to_decimal",
+]

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,0 +1,39 @@
+"""Model package exports."""
+
+from .finance import (
+    CapexItem,
+    CapexPlan,
+    CostPlan,
+    FinanceBundle,
+    LoanItem,
+    LoanSchedule,
+    MONTH_SEQUENCE,
+    MonthlySeries,
+    SalesItem,
+    SalesPlan,
+    TaxPolicy,
+    DEFAULT_CAPEX_PLAN,
+    DEFAULT_COST_PLAN,
+    DEFAULT_LOAN_SCHEDULE,
+    DEFAULT_SALES_PLAN,
+    DEFAULT_TAX_POLICY,
+)
+
+__all__ = [
+    "CapexItem",
+    "CapexPlan",
+    "CostPlan",
+    "FinanceBundle",
+    "LoanItem",
+    "LoanSchedule",
+    "MONTH_SEQUENCE",
+    "MonthlySeries",
+    "SalesItem",
+    "SalesPlan",
+    "TaxPolicy",
+    "DEFAULT_CAPEX_PLAN",
+    "DEFAULT_COST_PLAN",
+    "DEFAULT_LOAN_SCHEDULE",
+    "DEFAULT_SALES_PLAN",
+    "DEFAULT_TAX_POLICY",
+]

--- a/models/finance.py
+++ b/models/finance.py
@@ -1,0 +1,289 @@
+"""Pydantic models representing the core financial planning inputs."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Dict, Iterable, List, Literal, Sequence
+
+from pydantic import BaseModel, Field, ValidationError, field_validator, model_validator
+
+MonthIndex = Literal[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+MONTH_SEQUENCE: Sequence[MonthIndex] = tuple(range(1, 13))  # type: ignore[arg-type]
+
+
+class MonthlySeries(BaseModel):
+    """A 12-month series of Decimal amounts."""
+
+    amounts: List[Decimal] = Field(default_factory=list)
+
+    @field_validator("amounts", mode="before")
+    @classmethod
+    def _coerce_list(cls, value: Iterable[Decimal] | Dict[int, Decimal]) -> List[Decimal]:
+        if isinstance(value, dict):
+            ordered = [value.get(month, Decimal("0")) for month in MONTH_SEQUENCE]
+            return [Decimal(str(v)) for v in ordered]
+        if not isinstance(value, Iterable):
+            raise TypeError("月次データは12項目のリストで入力してください。")
+        coerced = [Decimal(str(v)) for v in value]
+        return coerced
+
+    @model_validator(mode="after")
+    def _ensure_twelve(self) -> "MonthlySeries":
+        if len(self.amounts) != 12:
+            raise ValueError("月次データは必ず12ヶ月分を入力してください。")
+        return self
+
+    def total(self) -> Decimal:
+        return sum(self.amounts, start=Decimal("0"))
+
+    def by_month(self) -> Dict[MonthIndex, Decimal]:
+        return {month: self.amounts[i] for i, month in enumerate(MONTH_SEQUENCE)}
+
+
+class SalesItem(BaseModel):
+    """Monthly sales for a specific product sold through a channel."""
+
+    channel: str
+    product: str
+    monthly: MonthlySeries = Field(default_factory=MonthlySeries)
+
+    @property
+    def annual_total(self) -> Decimal:
+        return self.monthly.total()
+
+
+class SalesPlan(BaseModel):
+    """Sales broken down by channel, product and month."""
+
+    items: List[SalesItem] = Field(default_factory=list)
+
+    def total_by_month(self) -> Dict[MonthIndex, Decimal]:
+        totals = {month: Decimal("0") for month in MONTH_SEQUENCE}
+        for item in self.items:
+            for month, value in item.monthly.by_month().items():
+                totals[month] += value
+        return totals
+
+    def annual_total(self) -> Decimal:
+        return sum((item.annual_total for item in self.items), start=Decimal("0"))
+
+    def channels(self) -> List[str]:
+        return sorted({item.channel for item in self.items})
+
+    def products(self) -> List[str]:
+        return sorted({item.product for item in self.items})
+
+
+class CostPlan(BaseModel):
+    """Cost configuration split into variable ratios and fixed amounts."""
+
+    variable_ratios: Dict[str, Decimal] = Field(default_factory=dict)
+    fixed_costs: Dict[str, Decimal] = Field(default_factory=dict)
+    gross_linked_ratios: Dict[str, Decimal] = Field(default_factory=dict)
+    non_operating_income: Dict[str, Decimal] = Field(default_factory=dict)
+    non_operating_expenses: Dict[str, Decimal] = Field(default_factory=dict)
+
+    @field_validator("variable_ratios", "gross_linked_ratios", mode="before")
+    @classmethod
+    def _coerce_ratio_dict(cls, value: Dict[str, Decimal] | None) -> Dict[str, Decimal]:
+        if value is None:
+            return {}
+        return {str(k): Decimal(str(v)) for k, v in value.items()}
+
+    @field_validator(
+        "fixed_costs", "non_operating_income", "non_operating_expenses", mode="before"
+    )
+    @classmethod
+    def _coerce_amount_dict(cls, value: Dict[str, Decimal] | None) -> Dict[str, Decimal]:
+        if value is None:
+            return {}
+        return {str(k): Decimal(str(v)) for k, v in value.items()}
+
+    @model_validator(mode="after")
+    def _check_ranges(self) -> "CostPlan":
+        for label, ratios in (
+            ("variable_ratios", self.variable_ratios),
+            ("gross_linked_ratios", self.gross_linked_ratios),
+        ):
+            for code, ratio in ratios.items():
+                if ratio < Decimal("0") or ratio > Decimal("1"):
+                    raise ValueError(f"{label} の '{code}' は0〜1の範囲に収めてください。")
+        for label, amounts in (
+            ("fixed_costs", self.fixed_costs),
+            ("non_operating_income", self.non_operating_income),
+            ("non_operating_expenses", self.non_operating_expenses),
+        ):
+            for code, amount in amounts.items():
+                if amount < Decimal("0"):
+                    raise ValueError(f"{label} の '{code}' は0以上の金額を入力してください。")
+        return self
+
+
+class CapexItem(BaseModel):
+    """Single capital expenditure entry."""
+
+    name: str
+    amount: Decimal
+    start_month: MonthIndex
+    useful_life_years: int = Field(ge=1, le=20)
+
+    @field_validator("amount", mode="before")
+    @classmethod
+    def _coerce_amount(cls, value: Decimal) -> Decimal:
+        return Decimal(str(value))
+
+    @model_validator(mode="after")
+    def _ensure_positive_amount(self) -> "CapexItem":
+        if self.amount <= 0:
+            raise ValueError("投資金額は正の値を入力してください。")
+        return self
+
+    def annual_depreciation(self) -> Decimal:
+        life_months = Decimal(self.useful_life_years * 12)
+        return self.amount / (life_months / Decimal("12"))
+
+
+class CapexPlan(BaseModel):
+    items: List[CapexItem] = Field(default_factory=list)
+
+    def annual_depreciation(self) -> Decimal:
+        return sum((item.annual_depreciation() for item in self.items), start=Decimal("0"))
+
+    def total_investment(self) -> Decimal:
+        return sum((item.amount for item in self.items), start=Decimal("0"))
+
+
+class LoanItem(BaseModel):
+    """Definition of a single borrowing schedule."""
+
+    name: str
+    principal: Decimal
+    interest_rate: Decimal = Field(ge=Decimal("0"), le=Decimal("0.2"))
+    term_months: int = Field(ge=1, le=600)
+    start_month: MonthIndex
+    repayment_type: Literal["equal_principal", "interest_only"] = "equal_principal"
+
+    @field_validator("principal", mode="before")
+    @classmethod
+    def _coerce_principal(cls, value: Decimal) -> Decimal:
+        return Decimal(str(value))
+
+    @field_validator("interest_rate", mode="before")
+    @classmethod
+    def _coerce_rate(cls, value: Decimal) -> Decimal:
+        rate = Decimal(str(value))
+        if rate < Decimal("0") or rate > Decimal("0.2"):
+            raise ValueError("金利は0%〜20%の範囲で入力してください。")
+        return rate
+
+    @model_validator(mode="after")
+    def _ensure_positive_principal(self) -> "LoanItem":
+        if self.principal <= 0:
+            raise ValueError("借入元本は正の値を入力してください。")
+        return self
+
+    def annual_interest(self) -> Decimal:
+        return self.principal * self.interest_rate
+
+
+class LoanSchedule(BaseModel):
+    loans: List[LoanItem] = Field(default_factory=list)
+
+    def annual_interest(self) -> Decimal:
+        return sum((loan.annual_interest() for loan in self.loans), start=Decimal("0"))
+
+    def outstanding_principal(self) -> Decimal:
+        return sum((loan.principal for loan in self.loans), start=Decimal("0"))
+
+
+class TaxPolicy(BaseModel):
+    corporate_tax_rate: Decimal = Field(default=Decimal("0.30"))
+    consumption_tax_rate: Decimal = Field(default=Decimal("0.10"))
+    dividend_payout_ratio: Decimal = Field(default=Decimal("0.0"))
+
+    @field_validator(
+        "corporate_tax_rate", "consumption_tax_rate", "dividend_payout_ratio", mode="before"
+    )
+    @classmethod
+    def _coerce_rate(cls, value: Decimal) -> Decimal:
+        rate = Decimal(str(value))
+        return rate
+
+    @model_validator(mode="after")
+    def _validate_ranges(self) -> "TaxPolicy":
+        if not Decimal("0") <= self.corporate_tax_rate <= Decimal("0.55"):
+            raise ValueError("法人税率は0%〜55%の範囲で設定してください。")
+        if not Decimal("0") <= self.consumption_tax_rate <= Decimal("0.20"):
+            raise ValueError("消費税率は0%〜20%の範囲で設定してください。")
+        if not Decimal("0") <= self.dividend_payout_ratio <= Decimal("1"):
+            raise ValueError("配当性向は0%〜100%の範囲で設定してください。")
+        return self
+
+    def effective_tax(self, ordinary_income: Decimal) -> Decimal:
+        if ordinary_income <= 0:
+            return Decimal("0")
+        return ordinary_income * self.corporate_tax_rate
+
+    def projected_dividend(self, net_income: Decimal) -> Decimal:
+        if net_income <= 0:
+            return Decimal("0")
+        return net_income * self.dividend_payout_ratio
+
+
+@dataclass(frozen=True)
+class FinanceBundle:
+    """Convenience container to pass around typed plan inputs."""
+
+    sales: SalesPlan
+    costs: CostPlan
+    capex: CapexPlan
+    loans: LoanSchedule
+    tax: TaxPolicy
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, object]) -> "FinanceBundle":
+        try:
+            sales = SalesPlan(**data.get("sales", {}))
+            costs = CostPlan(**data.get("costs", {}))
+            capex = CapexPlan(**data.get("capex", {}))
+            loans = LoanSchedule(**data.get("loans", {}))
+            tax = TaxPolicy(**data.get("tax", {}))
+        except ValidationError as exc:  # pragma: no cover - defensive
+            raise ValueError("無効な財務データが含まれています。") from exc
+        return cls(sales=sales, costs=costs, capex=capex, loans=loans, tax=tax)
+
+
+DEFAULT_SALES_PLAN = SalesPlan(
+    items=[
+        SalesItem(
+            channel="オンライン",
+            product="主力製品",
+            monthly=MonthlySeries(amounts=[Decimal("80000000")] * 12),
+        ),
+    ]
+)
+
+DEFAULT_COST_PLAN = CostPlan(
+    variable_ratios={
+        "COGS_MAT": Decimal("0.25"),
+        "COGS_LBR": Decimal("0.06"),
+        "COGS_OUT_SRC": Decimal("0.10"),
+        "COGS_OUT_CON": Decimal("0.04"),
+        "COGS_OTH": Decimal("0.00"),
+    },
+    fixed_costs={
+        "OPEX_H": Decimal("170000000"),
+        "OPEX_K": Decimal("468000000"),
+        "OPEX_DEP": Decimal("6000000"),
+    },
+    non_operating_income={
+        "NOI_MISC": Decimal("100000"),
+    },
+    non_operating_expenses={
+        "NOE_INT": Decimal("7400000"),
+    },
+)
+
+DEFAULT_CAPEX_PLAN = CapexPlan(items=[])
+DEFAULT_LOAN_SCHEDULE = LoanSchedule(loans=[])
+DEFAULT_TAX_POLICY = TaxPolicy()

--- a/pages/00_Home.py
+++ b/pages/00_Home.py
@@ -1,4 +1,4 @@
-"""Streamlit entry point – forwards to the shared home page renderer."""
+"""Overview / tutorial page accessible from the sidebar."""
 from __future__ import annotations
 
 import streamlit as st
@@ -6,7 +6,7 @@ import streamlit as st
 from views import render_home_page
 
 st.set_page_config(
-    page_title="経営計画スタジオ",
+    page_title="経営計画スタジオ｜概要",
     page_icon="📊",
     layout="wide",
 )

--- a/pages/10_Inputs.py
+++ b/pages/10_Inputs.py
@@ -1,0 +1,394 @@
+"""Input hub for sales, costs, investments, borrowings and tax policy."""
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Dict, List
+
+import pandas as pd
+import streamlit as st
+
+from formatting import UNIT_FACTORS, format_amount_with_unit, format_ratio
+from models import (
+    DEFAULT_CAPEX_PLAN,
+    DEFAULT_COST_PLAN,
+    DEFAULT_LOAN_SCHEDULE,
+    DEFAULT_SALES_PLAN,
+    DEFAULT_TAX_POLICY,
+    MONTH_SEQUENCE,
+)
+from state import ensure_session_defaults
+from theme import inject_theme
+from validators import ValidationIssue, validate_bundle
+
+st.set_page_config(
+    page_title="経営計画スタジオ｜Inputs",
+    page_icon="🧾",
+    layout="wide",
+)
+
+inject_theme()
+ensure_session_defaults()
+
+finance_raw: Dict[str, Dict] = st.session_state.get("finance_raw", {})
+if not finance_raw:
+    finance_raw = {
+        "sales": DEFAULT_SALES_PLAN.model_dump(),
+        "costs": DEFAULT_COST_PLAN.model_dump(),
+        "capex": DEFAULT_CAPEX_PLAN.model_dump(),
+        "loans": DEFAULT_LOAN_SCHEDULE.model_dump(),
+        "tax": DEFAULT_TAX_POLICY.model_dump(),
+    }
+    st.session_state["finance_raw"] = finance_raw
+
+validation_errors: List[ValidationIssue] = st.session_state.get("finance_validation_errors", [])
+
+
+def _sales_dataframe(data: Dict) -> pd.DataFrame:
+    rows: List[Dict[str, float | str]] = []
+    for item in data.get("items", []):
+        row: Dict[str, float | str] = {
+            "チャネル": item.get("channel", ""),
+            "商品": item.get("product", ""),
+        }
+        monthly = item.get("monthly", {})
+        amounts = monthly.get("amounts") if isinstance(monthly, dict) else None
+        for idx, month in enumerate(MONTH_SEQUENCE, start=0):
+            key = f"月{month:02d}"
+            if isinstance(amounts, list):
+                value = Decimal(str(amounts[idx])) if idx < len(amounts) else Decimal("0")
+            elif isinstance(amounts, dict):
+                value = Decimal(str(amounts.get(month, 0)))
+            else:
+                value = Decimal("0")
+            row[key] = float(value)
+        rows.append(row)
+    if not rows:
+        rows.append({"チャネル": "オンライン", "商品": "主力製品", **{f"月{m:02d}": 0.0 for m in MONTH_SEQUENCE}})
+    df = pd.DataFrame(rows)
+    return df
+
+
+def _capex_dataframe(data: Dict) -> pd.DataFrame:
+    items = data.get("items", [])
+    if not items:
+        return pd.DataFrame(
+            [{"投資名": "新工場設備", "金額": 0.0, "開始月": 1, "耐用年数": 5}]
+        )
+    rows = []
+    for item in items:
+        rows.append(
+            {
+                "投資名": item.get("name", ""),
+                "金額": float(Decimal(str(item.get("amount", 0)))),
+                "開始月": int(item.get("start_month", 1)),
+                "耐用年数": int(item.get("useful_life_years", 5)),
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def _loan_dataframe(data: Dict) -> pd.DataFrame:
+    loans = data.get("loans", [])
+    if not loans:
+        return pd.DataFrame(
+            [
+                {
+                    "名称": "メインバンク借入",
+                    "元本": 0.0,
+                    "金利": 0.01,
+                    "返済期間(月)": 60,
+                    "開始月": 1,
+                    "返済タイプ": "equal_principal",
+                }
+            ]
+        )
+    rows = []
+    for loan in loans:
+        rows.append(
+            {
+                "名称": loan.get("name", ""),
+                "元本": float(Decimal(str(loan.get("principal", 0)))),
+                "金利": float(Decimal(str(loan.get("interest_rate", 0)))),
+                "返済期間(月)": int(loan.get("term_months", 12)),
+                "開始月": int(loan.get("start_month", 1)),
+                "返済タイプ": loan.get("repayment_type", "equal_principal"),
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+sales_df = _sales_dataframe(finance_raw.get("sales", {}))
+capex_df = _capex_dataframe(finance_raw.get("capex", {}))
+loan_df = _loan_dataframe(finance_raw.get("loans", {}))
+
+costs_defaults = finance_raw.get("costs", {})
+variable_ratios = costs_defaults.get("variable_ratios", {})
+fixed_costs = costs_defaults.get("fixed_costs", {})
+noi_defaults = costs_defaults.get("non_operating_income", {})
+noe_defaults = costs_defaults.get("non_operating_expenses", {})
+
+settings_state: Dict[str, object] = st.session_state.get("finance_settings", {})
+unit = str(settings_state.get("unit", "百万円"))
+unit_factor = UNIT_FACTORS.get(unit, Decimal("1"))
+
+st.title("🧾 データ入力ハブ")
+st.caption("売上からコスト、投資、借入、税制までを一箇所で整理します。保存すると全ページに反映されます。")
+
+sales_tab, cost_tab, invest_tab, tax_tab = st.tabs(
+    ["売上計画", "コスト計画", "投資・借入", "税制・メモ"]
+)
+
+with sales_tab:
+    st.subheader("売上計画：チャネル×商品×月")
+    st.caption("各行はチャネル×商品を表し、12ヶ月の売上高を入力します。単位は円ベースで扱われ、表示単位で丸められます。")
+    sales_df = st.data_editor(
+        sales_df,
+        num_rows="dynamic",
+        use_container_width=True,
+        key="sales_editor",
+    )
+    if any(err.field.startswith("sales") for err in validation_errors):
+        messages = "<br/>".join(err.message for err in validation_errors if err.field.startswith("sales"))
+        st.markdown(f"<div class='field-error'>{messages}</div>", unsafe_allow_html=True)
+
+with cost_tab:
+    st.subheader("コスト計画：変動費と固定費")
+    var_cols = st.columns(5)
+    var_codes = ["COGS_MAT", "COGS_LBR", "COGS_OUT_SRC", "COGS_OUT_CON", "COGS_OTH"]
+    var_labels = ["材料費", "外部労務費", "外注費(専属)", "外注費(委託)", "その他原価"]
+    variable_inputs: Dict[str, float] = {}
+    for col, code, label in zip(var_cols, var_codes, var_labels):
+        with col:
+            variable_inputs[code] = st.number_input(
+                f"{label} 原価率",
+                min_value=0.0,
+                max_value=1.0,
+                step=0.005,
+                value=float(variable_ratios.get(code, 0.0)),
+                format="%.3f",
+            )
+    st.caption("変動費は売上高に対する比率で入力します。0〜1の範囲で設定してください。")
+
+    fixed_cols = st.columns(3)
+    fixed_codes = ["OPEX_H", "OPEX_K", "OPEX_DEP"]
+    fixed_labels = ["人件費", "経費", "減価償却"]
+    fixed_inputs: Dict[str, float] = {}
+    for col, code, label in zip(fixed_cols, fixed_codes, fixed_labels):
+        with col:
+            base_value = Decimal(str(fixed_costs.get(code, 0.0)))
+            fixed_inputs[code] = st.number_input(
+                f"{label} ({unit})",
+                min_value=0.0,
+                step=1.0,
+                value=float(base_value / unit_factor),
+                format="%.0f",
+            )
+    st.caption("固定費は入力した単位で保存されます。")
+
+    st.markdown("#### 営業外収益 / 営業外費用")
+    noi_cols = st.columns(3)
+    noi_codes = ["NOI_MISC", "NOI_GRANT", "NOI_OTH"]
+    noi_labels = ["雑収入", "補助金", "その他"]
+    noi_inputs: Dict[str, float] = {}
+    for col, code, label in zip(noi_cols, noi_codes, noi_labels):
+        with col:
+            base_value = Decimal(str(noi_defaults.get(code, 0.0)))
+            noi_inputs[code] = st.number_input(
+                f"{label} ({unit})",
+                min_value=0.0,
+                step=1.0,
+                value=float(base_value / unit_factor),
+            )
+
+    noe_cols = st.columns(2)
+    noe_codes = ["NOE_INT", "NOE_OTH"]
+    noe_labels = ["支払利息", "その他費用"]
+    noe_inputs: Dict[str, float] = {}
+    for col, code, label in zip(noe_cols, noe_codes, noe_labels):
+        with col:
+            base_value = Decimal(str(noe_defaults.get(code, 0.0)))
+            noe_inputs[code] = st.number_input(
+                f"{label} ({unit})",
+                min_value=0.0,
+                step=1.0,
+                value=float(base_value / unit_factor),
+            )
+
+    if any(err.field.startswith("costs") for err in validation_errors):
+        messages = "<br/>".join(err.message for err in validation_errors if err.field.startswith("costs"))
+        st.markdown(f"<div class='field-error'>{messages}</div>", unsafe_allow_html=True)
+
+with invest_tab:
+    st.subheader("投資・借入計画")
+    st.markdown("#### 設備投資 (Capex)")
+    capex_df = st.data_editor(
+        capex_df,
+        num_rows="dynamic",
+        use_container_width=True,
+        column_config={
+            "金額": st.column_config.NumberColumn("金額 (円)", min_value=0.0, step=1_000_000.0, format="%.0f"),
+            "開始月": st.column_config.NumberColumn("開始月", min_value=1, max_value=12, step=1),
+            "耐用年数": st.column_config.NumberColumn("耐用年数 (年)", min_value=1, max_value=20, step=1),
+        },
+        key="capex_editor",
+    )
+
+    st.markdown("#### 借入スケジュール")
+    loan_df = st.data_editor(
+        loan_df,
+        num_rows="dynamic",
+        use_container_width=True,
+        column_config={
+            "元本": st.column_config.NumberColumn("元本 (円)", min_value=0.0, step=1_000_000.0, format="%.0f"),
+            "金利": st.column_config.NumberColumn("金利", min_value=0.0, max_value=0.2, step=0.001, format="%.3f"),
+            "返済期間(月)": st.column_config.NumberColumn("返済期間 (月)", min_value=1, max_value=600, step=1),
+            "開始月": st.column_config.NumberColumn("開始月", min_value=1, max_value=12, step=1),
+            "返済タイプ": st.column_config.SelectboxColumn("返済タイプ", options=["equal_principal", "interest_only"]),
+        },
+        key="loan_editor",
+    )
+
+    if any(err.field.startswith("capex") for err in validation_errors):
+        messages = "<br/>".join(err.message for err in validation_errors if err.field.startswith("capex"))
+        st.markdown(f"<div class='field-error'>{messages}</div>", unsafe_allow_html=True)
+    if any(err.field.startswith("loans") for err in validation_errors):
+        messages = "<br/>".join(err.message for err in validation_errors if err.field.startswith("loans"))
+        st.markdown(f"<div class='field-error'>{messages}</div>", unsafe_allow_html=True)
+
+with tax_tab:
+    st.subheader("税制・備考")
+    tax_defaults = finance_raw.get("tax", {})
+    corporate_rate = st.number_input(
+        "法人税率 (0-55%)",
+        min_value=0.0,
+        max_value=0.55,
+        step=0.01,
+        value=float(tax_defaults.get("corporate_tax_rate", 0.3)),
+        format="%.2f",
+    )
+    consumption_rate = st.number_input(
+        "消費税率 (0-20%)",
+        min_value=0.0,
+        max_value=0.20,
+        step=0.01,
+        value=float(tax_defaults.get("consumption_tax_rate", 0.1)),
+        format="%.2f",
+    )
+    dividend_ratio = st.number_input(
+        "配当性向",
+        min_value=0.0,
+        max_value=1.0,
+        step=0.05,
+        value=float(tax_defaults.get("dividend_payout_ratio", 0.0)),
+        format="%.2f",
+    )
+
+    st.caption("税率は自動でバリデーションされます。")
+
+    if any(err.field.startswith("tax") for err in validation_errors):
+        messages = "<br/>".join(err.message for err in validation_errors if err.field.startswith("tax"))
+        st.markdown(f"<div class='field-error'>{messages}</div>", unsafe_allow_html=True)
+
+
+save_col, summary_col = st.columns([2, 1])
+with save_col:
+    if st.button("入力を検証して保存", type="primary"):
+        sales_data = {"items": []}
+        for _, row in sales_df.fillna(0).iterrows():
+            monthly_amounts = [Decimal(str(row[f"月{m:02d}"])) for m in MONTH_SEQUENCE]
+            sales_data["items"].append(
+                {
+                    "channel": str(row.get("チャネル", "")).strip() or "未設定",
+                    "product": str(row.get("商品", "")).strip() or "未設定",
+                    "monthly": {"amounts": monthly_amounts},
+                }
+            )
+
+        costs_data = {
+            "variable_ratios": {code: Decimal(str(value)) for code, value in variable_inputs.items()},
+            "fixed_costs": {code: Decimal(str(value)) * unit_factor for code, value in fixed_inputs.items()},
+            "non_operating_income": {code: Decimal(str(value)) * unit_factor for code, value in noi_inputs.items()},
+            "non_operating_expenses": {code: Decimal(str(value)) * unit_factor for code, value in noe_inputs.items()},
+        }
+
+        capex_data = {
+            "items": [
+                {
+                    "name": ("" if pd.isna(row.get("投資名", "")) else str(row.get("投資名", ""))).strip()
+                    or "未設定",
+                    "amount": Decimal(str(row.get("金額", 0) if not pd.isna(row.get("金額", 0)) else 0)),
+                    "start_month": int(row.get("開始月", 1) if not pd.isna(row.get("開始月", 1)) else 1),
+                    "useful_life_years": int(row.get("耐用年数", 5) if not pd.isna(row.get("耐用年数", 5)) else 5),
+                }
+                for _, row in capex_df.iterrows()
+                if Decimal(str(row.get("金額", 0) if not pd.isna(row.get("金額", 0)) else 0)) > 0
+            ]
+        }
+
+        loan_data = {
+            "loans": [
+                {
+                    "name": ("" if pd.isna(row.get("名称", "")) else str(row.get("名称", ""))).strip()
+                    or "借入",
+                    "principal": Decimal(
+                        str(row.get("元本", 0) if not pd.isna(row.get("元本", 0)) else 0)
+                    ),
+                    "interest_rate": Decimal(
+                        str(row.get("金利", 0) if not pd.isna(row.get("金利", 0)) else 0)
+                    ),
+                    "term_months": int(
+                        row.get("返済期間(月)", 12)
+                        if not pd.isna(row.get("返済期間(月)", 12))
+                        else 12
+                    ),
+                    "start_month": int(
+                        row.get("開始月", 1) if not pd.isna(row.get("開始月", 1)) else 1
+                    ),
+                    "repayment_type": (
+                        row.get("返済タイプ", "equal_principal")
+                        if row.get("返済タイプ", "equal_principal") in {"equal_principal", "interest_only"}
+                        else "equal_principal"
+                    ),
+                }
+                for _, row in loan_df.iterrows()
+                if Decimal(str(row.get("元本", 0) if not pd.isna(row.get("元本", 0)) else 0)) > 0
+            ]
+        }
+
+        tax_data = {
+            "corporate_tax_rate": Decimal(str(corporate_rate)),
+            "consumption_tax_rate": Decimal(str(consumption_rate)),
+            "dividend_payout_ratio": Decimal(str(dividend_ratio)),
+        }
+
+        bundle_dict = {
+            "sales": sales_data,
+            "costs": costs_data,
+            "capex": capex_data,
+            "loans": loan_data,
+            "tax": tax_data,
+        }
+
+        bundle, issues = validate_bundle(bundle_dict)
+        if issues:
+            st.session_state["finance_validation_errors"] = issues
+            st.toast("入力にエラーがあります。赤枠の項目を修正してください。", icon="❌")
+        else:
+            st.session_state["finance_validation_errors"] = []
+            st.session_state["finance_raw"] = bundle_dict
+            st.session_state["finance_models"] = {
+                "sales": bundle.sales,
+                "costs": bundle.costs,
+                "capex": bundle.capex,
+                "loans": bundle.loans,
+                "tax": bundle.tax,
+            }
+            st.toast("財務データを保存しました。", icon="✅")
+
+with summary_col:
+    total_sales = sum(
+        Decimal(str(row[f"月{m:02d}"])) for _, row in sales_df.iterrows() for m in MONTH_SEQUENCE
+    )
+    avg_ratio = sum(variable_inputs.values()) / len(variable_inputs) if variable_inputs else 0.0
+    st.metric("売上合計", format_amount_with_unit(total_sales, unit))
+    st.metric("平均原価率", format_ratio(avg_ratio))

--- a/pages/20_Analysis.py
+++ b/pages/20_Analysis.py
@@ -1,0 +1,150 @@
+"""Analytics page showing KPI dashboard, break-even analysis and cash flow."""
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Dict, List
+
+import altair as alt
+import pandas as pd
+import streamlit as st
+
+from calc import (
+    ITEMS,
+    compute,
+    generate_balance_sheet,
+    generate_cash_flow,
+    plan_from_models,
+    summarize_plan_metrics,
+)
+from formatting import format_amount_with_unit, format_ratio
+from state import ensure_session_defaults, load_finance_bundle
+from theme import inject_theme
+
+st.set_page_config(
+    page_title="経営計画スタジオ｜Analysis",
+    page_icon="📈",
+    layout="wide",
+)
+
+inject_theme()
+ensure_session_defaults()
+
+settings_state: Dict[str, object] = st.session_state.get("finance_settings", {})
+unit = str(settings_state.get("unit", "百万円"))
+fte = Decimal(str(settings_state.get("fte", 20)))
+fiscal_year = int(settings_state.get("fiscal_year", 2025))
+
+bundle, has_custom_inputs = load_finance_bundle()
+if not has_custom_inputs:
+    st.info("Inputsページでデータを保存すると、分析結果が更新されます。以下は既定値サンプルです。")
+
+plan_cfg = plan_from_models(
+    bundle.sales,
+    bundle.costs,
+    bundle.capex,
+    bundle.loans,
+    bundle.tax,
+    fte=fte,
+    unit=unit,
+)
+
+amounts = compute(plan_cfg)
+metrics = summarize_plan_metrics(amounts)
+bs_data = generate_balance_sheet(amounts, bundle.capex, bundle.loans, bundle.tax)
+cf_data = generate_cash_flow(amounts, bundle.capex, bundle.loans, bundle.tax)
+
+st.title("📈 KPI・損益分析")
+st.caption(f"FY{fiscal_year} / 表示単位: {unit} / FTE: {fte}")
+
+kpi_tab, be_tab, cash_tab = st.tabs(["KPIダッシュボード", "損益分岐点", "資金繰り"])
+
+with kpi_tab:
+    st.subheader("主要KPI")
+    top_cols = st.columns(4)
+    top_cols[0].metric("売上高", format_amount_with_unit(amounts.get("REV", Decimal("0")), unit))
+    top_cols[1].metric("粗利", format_amount_with_unit(amounts.get("GROSS", Decimal("0")), unit))
+    top_cols[2].metric("営業利益", format_amount_with_unit(amounts.get("OP", Decimal("0")), unit))
+    top_cols[3].metric("経常利益", format_amount_with_unit(amounts.get("ORD", Decimal("0")), unit))
+
+    ratio_cols = st.columns(3)
+    ratio_cols[0].metric("粗利率", format_ratio(metrics.get("gross_margin")))
+    ratio_cols[1].metric("営業利益率", format_ratio(metrics.get("op_margin")))
+    ratio_cols[2].metric("経常利益率", format_ratio(metrics.get("ord_margin")))
+
+    st.markdown("### PLサマリー")
+    pl_rows: List[Dict[str, object]] = []
+    for code, label, group in ITEMS:
+        if code in {"BE_SALES", "PC_SALES", "PC_GROSS", "PC_ORD", "LDR"}:
+            continue
+        value = amounts.get(code, Decimal("0"))
+        pl_rows.append({"カテゴリ": group, "項目": label, "金額": float(value)})
+    pl_df = pd.DataFrame(pl_rows)
+    st.dataframe(pl_df, use_container_width=True, hide_index=True)
+
+    st.markdown("### コスト構成比")
+    cost_codes = ["COGS_MAT", "COGS_LBR", "COGS_OUT_SRC", "COGS_OUT_CON", "COGS_OTH", "OPEX_H", "OPEX_K", "OPEX_DEP"]
+    cost_rows = []
+    revenue = amounts.get("REV", Decimal("0"))
+    for code in cost_codes:
+        label = next((lbl for item_code, lbl, _ in ITEMS if item_code == code), code)
+        value = amounts.get(code, Decimal("0"))
+        ratio = float((value / revenue) * Decimal("100")) if revenue > 0 else 0.0
+        cost_rows.append({"項目": label, "金額": float(value), "売上比%": ratio})
+    cost_df = pd.DataFrame(cost_rows)
+    if not cost_df.empty:
+        chart = (
+            alt.Chart(cost_df)
+            .mark_bar()
+            .encode(
+                x=alt.X("売上比%:Q", title="売上比率 (%)"),
+                y=alt.Y("項目:N", sort="-x"),
+                tooltip=["項目", alt.Tooltip("金額:Q", title="金額", format=","), alt.Tooltip("売上比%:Q", title="売上比", format=".1f")],
+            )
+            .properties(height=max(240, 20 * len(cost_df)))
+        )
+        st.altair_chart(chart, use_container_width=True)
+    else:
+        st.caption("コストデータが未設定です。")
+
+with be_tab:
+    st.subheader("損益分岐点分析")
+    be_sales = metrics.get("breakeven", Decimal("0"))
+    sales = amounts.get("REV", Decimal("0"))
+    ratio = (be_sales / sales) if sales > 0 else Decimal("0")
+
+    info_cols = st.columns(3)
+    info_cols[0].metric("損益分岐点売上高", format_amount_with_unit(be_sales, unit))
+    info_cols[1].metric("現在の売上高", format_amount_with_unit(sales, unit))
+    info_cols[2].metric("安全余裕度", format_ratio(Decimal("1") - ratio if sales > 0 else Decimal("0")))
+
+    st.progress(min(max(float(1 - ratio), 0.0), 1.0), "安全余裕度")
+    st.caption("進捗バーは売上高が損益分岐点をどの程度上回っているかを可視化します。")
+
+    st.markdown("### バランスシートのスナップショット")
+    bs_rows = []
+    for section, records in (("資産", bs_data["assets"]), ("負債・純資産", bs_data["liabilities"])):
+        for name, value in records.items():
+            bs_rows.append({"区分": section, "項目": name, "金額": float(value)})
+    bs_df = pd.DataFrame(bs_rows)
+    st.dataframe(bs_df, use_container_width=True, hide_index=True)
+
+with cash_tab:
+    st.subheader("キャッシュフロー")
+    cf_rows = [{"区分": key, "金額": float(value)} for key, value in cf_data.items()]
+    cf_df = pd.DataFrame(cf_rows)
+    st.dataframe(cf_df, use_container_width=True, hide_index=True)
+
+    chart = (
+        alt.Chart(cf_df)
+        .mark_bar()
+        .encode(
+            x=alt.X("区分:N", sort=None),
+            y=alt.Y("金額:Q", title="金額", axis=alt.Axis(format="~s")),
+            color=alt.Color("区分:N", legend=None),
+            tooltip=["区分", alt.Tooltip("金額:Q", title="金額", format=",")],
+        )
+        .properties(height=280)
+    )
+    st.altair_chart(chart, use_container_width=True)
+
+    st.caption("営業CFには減価償却費を足し戻し、税引後利益を反映しています。投資CFはCapex、財務CFは利息支払を表します。")

--- a/pages/30_Scenarios.py
+++ b/pages/30_Scenarios.py
@@ -1,0 +1,194 @@
+"""Scenario and sensitivity analysis page."""
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Dict, List
+
+import altair as alt
+import pandas as pd
+import streamlit as st
+
+from calc import compute, plan_from_models, summarize_plan_metrics
+from formatting import (
+    format_amount_with_unit,
+    format_delta,
+    format_ratio,
+    format_ratio_delta,
+)
+from state import ensure_session_defaults, load_finance_bundle
+from theme import inject_theme
+
+st.set_page_config(
+    page_title="経営計画スタジオ｜Scenarios",
+    page_icon="🧮",
+    layout="wide",
+)
+
+inject_theme()
+ensure_session_defaults()
+
+settings_state: Dict[str, object] = st.session_state.get("finance_settings", {})
+unit = str(settings_state.get("unit", "百万円"))
+fte = Decimal(str(settings_state.get("fte", 20)))
+
+bundle, has_custom_inputs = load_finance_bundle()
+if not has_custom_inputs:
+    st.info("入力データが未保存のため、既定値でシナリオを算出しています。")
+
+plan_cfg = plan_from_models(
+    bundle.sales,
+    bundle.costs,
+    bundle.capex,
+    bundle.loans,
+    bundle.tax,
+    fte=fte,
+    unit=unit,
+)
+base_amounts = compute(plan_cfg)
+base_metrics = summarize_plan_metrics(base_amounts)
+
+st.title("🧮 シナリオ / 感度分析")
+
+sensitivity_tab, scenario_tab = st.tabs(["感度分析", "シナリオ比較"])
+
+cogs_codes = ["COGS_MAT", "COGS_LBR", "COGS_OUT_SRC", "COGS_OUT_CON", "COGS_OTH"]
+opex_codes = ["OPEX_H", "OPEX_K", "OPEX_DEP"]
+
+with sensitivity_tab:
+    st.subheader("キー変数の感度分析")
+    st.caption("売上高、原価、販管費の変動が経常利益に与える影響を試算します。")
+
+    col1, col2, col3 = st.columns(3)
+    sales_pct = Decimal(str(col1.slider("売上高変動 (%)", min_value=-30, max_value=30, value=0, step=1))) / Decimal("100")
+    cogs_pct = Decimal(str(col2.slider("原価変動 (%)", min_value=-20, max_value=20, value=0, step=1))) / Decimal("100")
+    opex_pct = Decimal(str(col3.slider("販管費変動 (%)", min_value=-20, max_value=20, value=0, step=1))) / Decimal("100")
+
+    sales_override = plan_cfg.base_sales * (Decimal("1") + sales_pct)
+    amount_overrides: Dict[str, Decimal] = {}
+    for code in cogs_codes:
+        amount_overrides[code] = base_amounts.get(code, Decimal("0")) * (Decimal("1") + cogs_pct)
+    for code in opex_codes:
+        amount_overrides[code] = base_amounts.get(code, Decimal("0")) * (Decimal("1") + opex_pct)
+
+    sensitivity_amounts = compute(plan_cfg, sales_override=sales_override, amount_overrides=amount_overrides)
+    sensitivity_metrics = summarize_plan_metrics(sensitivity_amounts)
+
+    metric_cols = st.columns(3)
+    metric_cols[0].metric(
+        "売上高",
+        format_amount_with_unit(sensitivity_amounts.get("REV", Decimal("0")), unit),
+        delta=format_delta(sensitivity_amounts.get("REV", Decimal("0")) - base_amounts.get("REV", Decimal("0")), unit),
+    )
+    metric_cols[1].metric(
+        "粗利率",
+        format_ratio(sensitivity_metrics.get("gross_margin")),
+        delta=format_ratio_delta(
+            (sensitivity_metrics.get("gross_margin", Decimal("0")) or Decimal("0"))
+            - (base_metrics.get("gross_margin", Decimal("0")) or Decimal("0"))
+        ),
+    )
+    metric_cols[2].metric(
+        "経常利益",
+        format_amount_with_unit(sensitivity_amounts.get("ORD", Decimal("0")), unit),
+        delta=format_delta(sensitivity_amounts.get("ORD", Decimal("0")) - base_amounts.get("ORD", Decimal("0")), unit),
+    )
+
+    chart_df = pd.DataFrame(
+        {
+            "項目": ["売上高", "経常利益"],
+            "ベース": [float(base_amounts.get("REV", Decimal("0"))), float(base_amounts.get("ORD", Decimal("0")))],
+            "シナリオ": [
+                float(sensitivity_amounts.get("REV", Decimal("0"))),
+                float(sensitivity_amounts.get("ORD", Decimal("0"))),
+            ],
+        }
+    )
+    chart_df = chart_df.melt(id_vars="項目", var_name="ケース", value_name="金額")
+    chart = (
+        alt.Chart(chart_df)
+        .mark_bar()
+        .encode(
+            x=alt.X("項目:N", sort=None),
+            y=alt.Y("金額:Q", axis=alt.Axis(format="~s")),
+            color=alt.Color("ケース:N", scale=alt.Scale(range=["#8FA9C4", "#F2C57C"])),
+            column=alt.Column("ケース:N", header=alt.Header(labelOrient="bottom")),
+        )
+    )
+    st.altair_chart(chart, use_container_width=True)
+
+with scenario_tab:
+    st.subheader("シナリオ比較")
+    st.caption("売上・原価・販管費の変動率を設定し、ベースとの比較を行います。")
+
+    default_scenarios = [
+        {"シナリオ": "Base", "売上%": 0.0, "原価%": 0.0, "販管費%": 0.0},
+        {"シナリオ": "Optimistic", "売上%": 10.0, "原価%": -3.0, "販管費%": -2.0},
+        {"シナリオ": "Conservative", "売上%": -5.0, "原価%": 2.0, "販管費%": 1.0},
+    ]
+    scenario_state = st.session_state.setdefault("scenario_table", default_scenarios)
+    scenario_df = pd.DataFrame(scenario_state)
+    edited_df = st.data_editor(
+        scenario_df,
+        num_rows="dynamic",
+        use_container_width=True,
+        column_config={
+            "売上%": st.column_config.NumberColumn("売上変化%", min_value=-50.0, max_value=50.0, step=1.0),
+            "原価%": st.column_config.NumberColumn("原価変化%", min_value=-30.0, max_value=30.0, step=1.0),
+            "販管費%": st.column_config.NumberColumn("販管費変化%", min_value=-30.0, max_value=30.0, step=1.0),
+        },
+        hide_index=True,
+        key="scenario_editor_table",
+    )
+    st.session_state["scenario_table"] = edited_df.to_dict(orient="records")
+
+    comparison_rows = []
+    for _, row in edited_df.iterrows():
+        name = str(row.get("シナリオ", "Case")).strip() or "Case"
+        sales_factor = Decimal("1") + Decimal(str(row.get("売上%", 0.0))) / Decimal("100")
+        cogs_factor = Decimal("1") + Decimal(str(row.get("原価%", 0.0))) / Decimal("100")
+        opex_factor = Decimal("1") + Decimal(str(row.get("販管費%", 0.0))) / Decimal("100")
+
+        overrides: Dict[str, Decimal] = {}
+        for code in cogs_codes:
+            overrides[code] = base_amounts.get(code, Decimal("0")) * cogs_factor
+        for code in opex_codes:
+            overrides[code] = base_amounts.get(code, Decimal("0")) * opex_factor
+
+        scenario_amounts = compute(plan_cfg, sales_override=plan_cfg.base_sales * sales_factor, amount_overrides=overrides)
+        scenario_metrics = summarize_plan_metrics(scenario_amounts)
+
+        comparison_rows.append(
+            {
+                "シナリオ": name,
+                "売上高": format_amount_with_unit(scenario_amounts.get("REV", Decimal("0")), unit),
+                "経常利益": format_amount_with_unit(scenario_amounts.get("ORD", Decimal("0")), unit),
+                "経常利益率": format_ratio(scenario_metrics.get("ord_margin")),
+                "Δ売上": format_delta(
+                    scenario_amounts.get("REV", Decimal("0")) - base_amounts.get("REV", Decimal("0")), unit
+                ),
+                "Δ経常利益": format_delta(
+                    scenario_amounts.get("ORD", Decimal("0")) - base_amounts.get("ORD", Decimal("0")), unit
+                ),
+                "売上高数値": float(scenario_amounts.get("REV", Decimal("0"))),
+                "経常利益数値": float(scenario_amounts.get("ORD", Decimal("0"))),
+            }
+        )
+
+    comparison_df = pd.DataFrame(comparison_rows)
+    display_df = comparison_df.drop(columns=["売上高数値", "経常利益数値"], errors="ignore")
+    st.dataframe(display_df, use_container_width=True, hide_index=True)
+
+    chart_df = comparison_df.copy()
+    if not chart_df.empty:
+        chart = (
+            alt.Chart(chart_df)
+            .mark_bar()
+            .encode(
+                x=alt.X("シナリオ:N", sort=None),
+                y=alt.Y("経常利益数値:Q", axis=alt.Axis(format="~s")),
+                color=alt.Color("シナリオ:N", legend=None),
+                tooltip=["シナリオ", "経常利益", "経常利益率"],
+            )
+            .properties(height=280)
+        )
+        st.altair_chart(chart, use_container_width=True)

--- a/pages/40_Report.py
+++ b/pages/40_Report.py
@@ -1,0 +1,137 @@
+"""Report export page for PDF / Excel / Word outputs."""
+from __future__ import annotations
+
+import io
+from decimal import Decimal
+from typing import Dict
+
+import pandas as pd
+import streamlit as st
+from docx import Document
+from fpdf import FPDF
+
+from calc import compute, plan_from_models, summarize_plan_metrics
+from formatting import format_amount_with_unit, format_ratio
+from state import ensure_session_defaults, load_finance_bundle
+from theme import inject_theme
+
+st.set_page_config(
+    page_title="経営計画スタジオ｜Report",
+    page_icon="📝",
+    layout="wide",
+)
+
+inject_theme()
+ensure_session_defaults()
+
+settings_state: Dict[str, object] = st.session_state.get("finance_settings", {})
+unit = str(settings_state.get("unit", "百万円"))
+fte = Decimal(str(settings_state.get("fte", 20)))
+fiscal_year = int(settings_state.get("fiscal_year", 2025))
+
+bundle, has_custom_inputs = load_finance_bundle()
+if not has_custom_inputs:
+    st.info("入力データが未保存のため、既定値でレポートを生成します。")
+
+plan_cfg = plan_from_models(
+    bundle.sales,
+    bundle.costs,
+    bundle.capex,
+    bundle.loans,
+    bundle.tax,
+    fte=fte,
+    unit=unit,
+)
+
+amounts = compute(plan_cfg)
+metrics = summarize_plan_metrics(amounts)
+
+st.title("📝 レポート出力")
+st.caption("主要指標とKPIのサマリーをPDF / Excel / Word形式でダウンロードできます。")
+
+pdf_tab, excel_tab, word_tab = st.tabs(["PDF", "Excel", "Word"])
+
+pdf_summary = [
+    f"FY{fiscal_year} 計画サマリー",
+    f"売上高: {format_amount_with_unit(amounts.get('REV', Decimal('0')), unit)}",
+    f"粗利率: {format_ratio(metrics.get('gross_margin'))}",
+    f"経常利益: {format_amount_with_unit(amounts.get('ORD', Decimal('0')), unit)}",
+    f"経常利益率: {format_ratio(metrics.get('ord_margin'))}",
+    f"損益分岐点売上高: {format_amount_with_unit(metrics.get('breakeven', Decimal('0')), unit)}",
+]
+
+with pdf_tab:
+    st.subheader("PDFレポート")
+    pdf_buffer = io.BytesIO()
+    pdf = FPDF()
+    pdf.add_page()
+    pdf.set_font("Helvetica", size=14)
+    pdf.cell(0, 10, txt="経営計画スタジオ｜サマリーレポート", ln=True)
+    pdf.set_font("Helvetica", size=11)
+    for line in pdf_summary:
+        pdf.multi_cell(0, 8, line)
+    pdf.output(pdf_buffer)
+    st.download_button(
+        "📄 PDFダウンロード",
+        data=pdf_buffer.getvalue(),
+        file_name=f"plan_report_{fiscal_year}.pdf",
+        mime="application/pdf",
+    )
+
+with excel_tab:
+    st.subheader("Excelレポート")
+    excel_buffer = io.BytesIO()
+    with pd.ExcelWriter(excel_buffer, engine="openpyxl") as writer:
+        pd.DataFrame(
+            {
+                "項目": ["売上高", "粗利", "営業利益", "経常利益"],
+                "金額": [
+                    float(amounts.get("REV", Decimal("0"))),
+                    float(amounts.get("GROSS", Decimal("0"))),
+                    float(amounts.get("OP", Decimal("0"))),
+                    float(amounts.get("ORD", Decimal("0"))),
+                ],
+            }
+        ).to_excel(writer, sheet_name="PL", index=False)
+
+        pd.DataFrame(
+            {
+                "指標": ["粗利率", "営業利益率", "経常利益率", "損益分岐点"],
+                "値": [
+                    float(metrics.get("gross_margin", Decimal("0"))),
+                    float(metrics.get("op_margin", Decimal("0"))),
+                    float(metrics.get("ord_margin", Decimal("0"))),
+                    float(metrics.get("breakeven", Decimal("0"))),
+                ],
+            }
+        ).to_excel(writer, sheet_name="KPI", index=False)
+
+    st.download_button(
+        "📊 Excelダウンロード",
+        data=excel_buffer.getvalue(),
+        file_name=f"plan_report_{fiscal_year}.xlsx",
+        mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    )
+
+with word_tab:
+    st.subheader("Wordレポート")
+    doc = Document()
+    doc.add_heading("経営計画スタジオ レポート", level=1)
+    doc.add_paragraph(f"FY{fiscal_year} / 表示単位: {unit} / FTE: {fte}")
+    doc.add_paragraph("主要KPI")
+    bullet = doc.add_paragraph()
+    bullet.style = "List Bullet"
+    bullet.add_run(pdf_summary[1])
+    for line in pdf_summary[2:]:
+        para = doc.add_paragraph()
+        para.style = "List Bullet"
+        para.add_run(line)
+
+    word_buffer = io.BytesIO()
+    doc.save(word_buffer)
+    st.download_button(
+        "📝 Wordダウンロード",
+        data=word_buffer.getvalue(),
+        file_name=f"plan_report_{fiscal_year}.docx",
+        mime="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    )

--- a/pages/90_Settings.py
+++ b/pages/90_Settings.py
@@ -1,0 +1,73 @@
+"""Application settings for unit, language and default data."""
+from __future__ import annotations
+
+from typing import Dict
+
+import streamlit as st
+
+from models import (
+    DEFAULT_CAPEX_PLAN,
+    DEFAULT_COST_PLAN,
+    DEFAULT_LOAN_SCHEDULE,
+    DEFAULT_SALES_PLAN,
+    DEFAULT_TAX_POLICY,
+)
+from state import ensure_session_defaults
+from theme import inject_theme
+
+st.set_page_config(
+    page_title="経営計画スタジオ｜Settings",
+    page_icon="⚙️",
+    layout="wide",
+)
+
+inject_theme()
+ensure_session_defaults()
+
+settings_state: Dict[str, object] = st.session_state.get("finance_settings", {})
+unit = str(settings_state.get("unit", "百万円"))
+fte = float(settings_state.get("fte", 20.0))
+fiscal_year = int(settings_state.get("fiscal_year", 2025))
+language = str(settings_state.get("language", "ja"))
+
+st.title("⚙️ アプリ設定")
+st.caption("表示単位や言語、既定値をカスタマイズできます。変更は直ちに反映されます。")
+
+unit_tab, language_tab, defaults_tab = st.tabs(["単位・期間", "言語", "既定値リセット"])
+
+with unit_tab:
+    st.subheader("単位と会計期間")
+    unit = st.selectbox("表示単位", ["百万円", "千円", "円"], index=["百万円", "千円", "円"].index(unit))
+    fiscal_year = st.number_input("会計年度", min_value=2000, max_value=2100, step=1, value=fiscal_year)
+    fte = st.number_input("FTE (人)", min_value=0.0, step=0.5, value=fte)
+
+with language_tab:
+    st.subheader("言語設定")
+    language = st.selectbox("UI言語", ["ja", "en"], index=["ja", "en"].index(language) if language in {"ja", "en"} else 0)
+    if language == "ja":
+        st.caption("日本語UIを使用中です。英語UIは現在ベータ版です。")
+    else:
+        st.caption("English UI is experimental. Some strings may remain in Japanese.")
+
+with defaults_tab:
+    st.subheader("既定値のリセット")
+    st.caption("入力データを初期値に戻す場合は以下のボタンを使用してください。")
+    if st.button("既定値で再初期化", type="secondary"):
+        st.session_state["finance_raw"] = {
+            "sales": DEFAULT_SALES_PLAN.model_dump(),
+            "costs": DEFAULT_COST_PLAN.model_dump(),
+            "capex": DEFAULT_CAPEX_PLAN.model_dump(),
+            "loans": DEFAULT_LOAN_SCHEDULE.model_dump(),
+            "tax": DEFAULT_TAX_POLICY.model_dump(),
+        }
+        st.session_state.pop("finance_models", None)
+        st.toast("既定値にリセットしました。", icon="✅")
+
+if st.button("設定を保存", type="primary"):
+    st.session_state["finance_settings"] = {
+        "unit": unit,
+        "language": language,
+        "fte": float(fte),
+        "fiscal_year": int(fiscal_year),
+    }
+    st.toast("設定を保存しました。", icon="✅")

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,6 @@ matplotlib>=3.9.0; python_version >= '3.13'
 openpyxl>=3.1.2
 plotly>=5.24.0
 altair>=5.2.0
+pydantic>=2.5.0
+fpdf2>=2.7.9
+python-docx>=0.8.11

--- a/theme.py
+++ b/theme.py
@@ -1,0 +1,205 @@
+"""Centralised colour scheme and style helpers."""
+from __future__ import annotations
+
+from typing import Dict
+
+import streamlit as st
+
+THEME_COLORS: Dict[str, str] = {
+    "background": "#F7F9FB",
+    "surface": "#FFFFFF",
+    "surface_alt": "#E8F1FA",
+    "primary": "#1F4E79",
+    "primary_light": "#4F83B3",
+    "accent": "#F2C57C",
+    "positive": "#70A9A1",
+    "positive_strong": "#2B7A78",
+    "negative": "#F28F8F",
+    "neutral": "#C2D3E5",
+    "text": "#203040",
+    "text_subtle": "#596B7A",
+}
+
+CUSTOM_STYLE = f"""
+<style>
+:root {{
+    --base-bg: {THEME_COLORS["background"]};
+    --surface: {THEME_COLORS["surface"]};
+    --surface-alt: {THEME_COLORS["surface_alt"]};
+    --primary: {THEME_COLORS["primary"]};
+    --primary-light: {THEME_COLORS["primary_light"]};
+    --accent: {THEME_COLORS["accent"]};
+    --positive: {THEME_COLORS["positive"]};
+    --positive-strong: {THEME_COLORS["positive_strong"]};
+    --negative: {THEME_COLORS["negative"]};
+    --neutral: {THEME_COLORS["neutral"]};
+    --text-color: {THEME_COLORS["text"]};
+    --text-subtle: {THEME_COLORS["text_subtle"]};
+}}
+
+html, body, [data-testid="stAppViewContainer"] {{
+    background-color: var(--base-bg);
+    color: var(--text-color);
+    font-family: "Noto Sans JP", "Hiragino Sans", "Yu Gothic", sans-serif;
+}}
+
+[data-testid="stSidebar"] {{
+    background: linear-gradient(180deg, var(--primary) 0%, var(--primary-light) 100%);
+    color: #F7FAFC;
+}}
+
+[data-testid="stSidebar"] * {{
+    color: #F7FAFC !important;
+}}
+
+.stTabs [role="tablist"] {{
+    gap: 0.4rem;
+    border-bottom: 1px solid var(--neutral);
+}}
+
+.stTabs [role="tab"] {{
+    font-weight: 600;
+    padding: 0.85rem 1.4rem;
+    border-radius: 14px 14px 0 0;
+    background-color: transparent;
+    color: var(--text-subtle);
+}}
+
+.stTabs [role="tab"][aria-selected="true"] {{
+    background-color: var(--surface);
+    color: var(--primary);
+    box-shadow: 0 -2px 20px rgba(31, 78, 121, 0.08);
+    border-bottom: 3px solid var(--accent);
+}}
+
+div[data-testid="stMetric"] {{
+    background: linear-gradient(135deg, var(--surface) 0%, var(--surface-alt) 100%);
+    border-radius: 18px;
+    padding: 1.15rem 1.3rem;
+    box-shadow: 0 14px 28px rgba(31, 78, 121, 0.08);
+    backdrop-filter: blur(6px);
+}}
+
+div[data-testid="stMetric"] [data-testid="stMetricLabel"] {{
+    font-size: 0.92rem;
+    color: var(--text-subtle);
+}}
+
+div[data-testid="stMetric"] [data-testid="stMetricValue"] {{
+    color: var(--primary);
+    font-weight: 700;
+}}
+
+div[data-testid="stMetric"] [data-testid="stMetricDelta"] {{
+    color: var(--accent) !important;
+}}
+
+div[data-testid="stDataFrame"] {{
+    background-color: var(--surface);
+    border-radius: 18px;
+    padding: 0.6rem 0.8rem 0.9rem 0.8rem;
+    box-shadow: 0 12px 26px rgba(31, 78, 121, 0.06);
+}}
+
+button[kind="primary"] {{
+    background-color: var(--primary);
+    border-radius: 999px;
+    border: none;
+    box-shadow: 0 10px 20px rgba(31, 78, 121, 0.15);
+}}
+
+button[kind="primary"]:hover {{
+    background-color: var(--primary-light);
+}}
+
+.hero-card {{
+    background: linear-gradient(135deg, rgba(93, 169, 233, 0.92) 0%, rgba(112, 169, 161, 0.92) 100%);
+    color: #ffffff;
+    padding: 2.2rem 2.8rem;
+    border-radius: 26px;
+    box-shadow: 0 24px 48px rgba(22, 60, 90, 0.25);
+    margin-bottom: 1.5rem;
+}}
+
+.hero-card h1 {{
+    margin: 0 0 0.6rem 0;
+    font-size: 2.35rem;
+    font-weight: 700;
+}}
+
+.hero-card p {{
+    margin: 0;
+    font-size: 1.08rem;
+    opacity: 0.92;
+}}
+
+.insight-card {{
+    background-color: var(--surface);
+    border-radius: 18px;
+    padding: 1.1rem 1.3rem;
+    box-shadow: 0 12px 24px rgba(31, 78, 121, 0.08);
+    border-left: 6px solid var(--primary-light);
+    margin-bottom: 1rem;
+}}
+
+.insight-card.positive {{
+    border-left-color: var(--positive);
+}}
+
+.insight-card.warning {{
+    border-left-color: var(--accent);
+}}
+
+.insight-card.alert {{
+    border-left-color: var(--negative);
+}}
+
+.insight-card h4 {{
+    margin: 0 0 0.4rem 0;
+    font-size: 1.05rem;
+    color: var(--primary);
+}}
+
+.insight-card p {{
+    margin: 0;
+    font-size: 0.95rem;
+    color: var(--text-subtle);
+    line-height: 1.55;
+}}
+
+.anomaly-table caption {{
+    caption-side: top;
+    font-weight: 600;
+    color: var(--primary);
+}}
+
+.ai-badge {{
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    background-color: rgba(112, 169, 161, 0.16);
+    color: var(--positive-strong);
+    border-radius: 999px;
+    padding: 0.35rem 0.9rem;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+}}
+
+.field-error {{
+    border: 1px solid {THEME_COLORS["negative"]};
+    border-radius: 12px;
+    padding: 0.8rem;
+    background-color: rgba(242, 143, 143, 0.12);
+    color: {THEME_COLORS["negative"]};
+}}
+</style>
+"""
+
+
+def inject_theme() -> None:
+    """Apply the shared CSS theme to the current page."""
+
+    st.markdown(CUSTOM_STYLE, unsafe_allow_html=True)
+
+
+__all__ = ["THEME_COLORS", "CUSTOM_STYLE", "inject_theme"]

--- a/validators.py
+++ b/validators.py
@@ -1,0 +1,114 @@
+"""Validation helpers for user supplied financial inputs."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Tuple
+
+from pydantic import ValidationError
+
+from models import (
+    CapexPlan,
+    CostPlan,
+    FinanceBundle,
+    LoanSchedule,
+    SalesPlan,
+    TaxPolicy,
+)
+
+
+@dataclass(frozen=True)
+class ValidationIssue:
+    """Represents a validation error for a specific field."""
+
+    field: str
+    message: str
+
+
+def _issues_from_error(prefix: str, error: ValidationError) -> List[ValidationIssue]:
+    issues: List[ValidationIssue] = []
+    for detail in error.errors():
+        path = ".".join(str(part) for part in detail.get("loc", ()))
+        message = detail.get("msg", "不正な値です。")
+        field = f"{prefix}.{path}" if prefix and path else prefix or path
+        issues.append(ValidationIssue(field=field, message=message))
+    return issues
+
+
+def validate_sales(data: Dict[str, Any]) -> Tuple[SalesPlan | None, List[ValidationIssue]]:
+    try:
+        plan = SalesPlan(**data)
+        return plan, []
+    except ValidationError as exc:
+        return None, _issues_from_error("sales", exc)
+
+
+def validate_costs(data: Dict[str, Any]) -> Tuple[CostPlan | None, List[ValidationIssue]]:
+    try:
+        plan = CostPlan(**data)
+        return plan, []
+    except ValidationError as exc:
+        return None, _issues_from_error("costs", exc)
+
+
+def validate_capex(data: Dict[str, Any]) -> Tuple[CapexPlan | None, List[ValidationIssue]]:
+    try:
+        plan = CapexPlan(**data)
+        return plan, []
+    except ValidationError as exc:
+        return None, _issues_from_error("capex", exc)
+
+
+def validate_loans(data: Dict[str, Any]) -> Tuple[LoanSchedule | None, List[ValidationIssue]]:
+    try:
+        schedule = LoanSchedule(**data)
+        return schedule, []
+    except ValidationError as exc:
+        return None, _issues_from_error("loans", exc)
+
+
+def validate_tax(data: Dict[str, Any]) -> Tuple[TaxPolicy | None, List[ValidationIssue]]:
+    try:
+        policy = TaxPolicy(**data)
+        return policy, []
+    except ValidationError as exc:
+        return None, _issues_from_error("tax", exc)
+
+
+def validate_bundle(data: Dict[str, Any]) -> Tuple[FinanceBundle | None, List[ValidationIssue]]:
+    """Validate a nested dictionary covering all plan components."""
+
+    sales, sales_errs = validate_sales(data.get("sales", {}))
+    costs, cost_errs = validate_costs(data.get("costs", {}))
+    capex, capex_errs = validate_capex(data.get("capex", {}))
+    loans, loan_errs = validate_loans(data.get("loans", {}))
+    tax, tax_errs = validate_tax(data.get("tax", {}))
+
+    issues: List[ValidationIssue] = []
+    issues.extend(sales_errs)
+    issues.extend(cost_errs)
+    issues.extend(capex_errs)
+    issues.extend(loan_errs)
+    issues.extend(tax_errs)
+
+    if issues:
+        return None, issues
+
+    assert sales and costs and capex and loans and tax  # for mypy/static typing
+    bundle = FinanceBundle(sales=sales, costs=costs, capex=capex, loans=loans, tax=tax)
+    return bundle, []
+
+
+def collect_error_messages(issues: Iterable[ValidationIssue]) -> str:
+    return "\n".join(f"[{issue.field}] {issue.message}" for issue in issues)
+
+
+__all__ = [
+    "ValidationIssue",
+    "validate_sales",
+    "validate_costs",
+    "validate_capex",
+    "validate_loans",
+    "validate_tax",
+    "validate_bundle",
+    "collect_error_messages",
+]

--- a/views/__init__.py
+++ b/views/__init__.py
@@ -1,0 +1,5 @@
+"""View helper modules for Streamlit pages."""
+
+from .home import render_home_page
+
+__all__ = ["render_home_page"]

--- a/views/home.py
+++ b/views/home.py
@@ -1,0 +1,106 @@
+"""Render logic for the overview / tutorial home page."""
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Dict
+
+import streamlit as st
+
+from calc import compute, plan_from_models, summarize_plan_metrics
+from formatting import format_amount_with_unit, format_ratio
+from state import ensure_session_defaults, load_finance_bundle, reset_app_state
+from theme import inject_theme
+from ui.chrome import HeaderActions, render_app_footer, render_app_header, render_usage_guide_panel
+
+
+def render_home_page() -> None:
+    """Render the home/overview page that appears in both root and pages menu."""
+
+    inject_theme()
+    ensure_session_defaults()
+
+    header_actions: HeaderActions = render_app_header(
+        title="経営計画スタジオ",
+        subtitle="入力→分析→シナリオ→レポートをワンストップで。型安全な計算ロジックで意思決定をサポートします。",
+    )
+
+    if header_actions.reset_requested:
+        reset_app_state()
+        st.experimental_rerun()
+
+    if header_actions.toggled_help:
+        st.session_state["show_usage_guide"] = not st.session_state.get("show_usage_guide", False)
+
+    render_usage_guide_panel()
+
+    with st.container():
+        st.markdown(
+            """
+            <div class="hero-card">
+                <h1>McKinsey Inspired 経営計画ダッシュボード</h1>
+                <p>チャネル×商品×月次の売上設計からKPI分析、シナリオ比較、ドキュメント出力までを一気通貫で支援します。</p>
+            </div>
+            """,
+            unsafe_allow_html=True,
+        )
+
+    settings_state: Dict[str, object] = st.session_state.get("finance_settings", {})
+    unit = str(settings_state.get("unit", "百万円"))
+    fte = Decimal(str(settings_state.get("fte", 20)))
+    fiscal_year = int(settings_state.get("fiscal_year", 2025))
+
+    bundle, has_custom_inputs = load_finance_bundle()
+
+    summary_tab, tutorial_tab = st.tabs(["概要", "チュートリアル"])
+
+    with summary_tab:
+        st.subheader("📌 現状サマリー")
+
+        if not has_custom_inputs:
+            st.info("入力ページでデータを保存すると、ここに最新のKPIが表示されます。")
+
+        plan_cfg = plan_from_models(
+            bundle.sales,
+            bundle.costs,
+            bundle.capex,
+            bundle.loans,
+            bundle.tax,
+            fte=fte,
+            unit=unit,
+        )
+        amounts = compute(plan_cfg)
+        metrics = summarize_plan_metrics(amounts)
+
+        metric_cols = st.columns(4)
+        metric_cols[0].metric("売上高", format_amount_with_unit(amounts.get("REV", Decimal("0")), unit))
+        metric_cols[1].metric("粗利率", format_ratio(metrics.get("gross_margin")))
+        metric_cols[2].metric("経常利益", format_amount_with_unit(amounts.get("ORD", Decimal("0")), unit))
+        metric_cols[3].metric("損益分岐点売上高", format_amount_with_unit(metrics.get("breakeven"), unit))
+
+        st.caption(f"FY{fiscal_year} 計画 ｜ 表示単位: {unit} ｜ FTE: {fte}")
+
+        st.markdown("### 次のステップ")
+        st.markdown(
+            """
+            1. **Inputs** ページで売上・原価・費用・投資・借入・税制を登録する
+            2. **Analysis** ページでPL/BS/CFとKPIを確認し、損益分岐点や資金繰りをチェック
+            3. **Scenarios** ページで感度分析やシナリオ比較を行い、意思決定を支援
+            4. **Report** ページでPDF / Excel / Word を生成し、ステークホルダーと共有
+            5. **Settings** ページで単位や言語、既定値をカスタマイズ
+            """
+        )
+
+    with tutorial_tab:
+        st.subheader("🧭 チュートリアル")
+        st.markdown(
+            """
+            - **セッションの保持**: サイドバーのページ遷移でも入力値はセッションステートに保存されます。
+            - **URLダイレクトアクセス**: 各ページは初期化時に既定値をロードし、入力が無くても破綻しないようにガードしています。
+            - **型安全な計算**: すべての計算は Pydantic モデルを通じて検証され、通貨は Decimal 基本で処理されます。
+            - **エラーハンドリング**: 入力チェックに失敗すると、赤いトーストとフィールド強調で異常値を通知します。
+            """
+        )
+
+    render_app_footer(
+        caption="© 経営計画スタジオ | 情報設計の最適化と精緻な財務モデリングを提供します。",
+    )


### PR DESCRIPTION
## Summary
- restructure the Streamlit app into a multi-page layout covering inputs, analysis, scenarios, reporting, and settings
- introduce typed Pydantic finance models, calculation helpers, and validation utilities to drive PL/BS/CF generation
- add themed styling plus export tooling for PDF/Excel/Word outputs backed by the shared data models

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68cea05a1fe88323af4223f768e9dbaf