### PR TITLE
Enhance input flow and analytics visualizations

### DIFF
--- a/pages/10_Inputs.py
+++ b/pages/10_Inputs.py
@@ -1,7 +1,9 @@
 """Input hub for sales, costs, investments, borrowings and tax policy."""
 from __future__ import annotations
 
+import io
 from decimal import Decimal
+from pathlib import Path
 from typing import Dict, List
 
 import pandas as pd
@@ -42,6 +44,144 @@ if not finance_raw:
 
 validation_errors: List[ValidationIssue] = st.session_state.get("finance_validation_errors", [])
 
+
+MONTH_COLUMNS = [f"月{m:02d}" for m in MONTH_SEQUENCE]
+SALES_TEMPLATE_STATE_KEY = "sales_template_df"
+SALES_CHANNEL_COUNTER_KEY = "sales_channel_counter"
+SALES_PRODUCT_COUNTER_KEY = "sales_product_counter"
+MAX_UPLOAD_BYTES = 5 * 1024 * 1024
+ALLOWED_MIME_TYPES = {
+    "text/csv",
+    "application/vnd.ms-excel",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+}
+ALLOWED_EXTENSIONS = {".csv", ".xlsx"}
+
+
+def _ensure_sales_template_state(base_df: pd.DataFrame) -> None:
+    if SALES_TEMPLATE_STATE_KEY not in st.session_state:
+        st.session_state[SALES_TEMPLATE_STATE_KEY] = base_df.copy()
+        unique_channels = base_df["チャネル"].dropna().unique()
+        unique_products = base_df["商品"].dropna().unique()
+        st.session_state[SALES_CHANNEL_COUNTER_KEY] = len(unique_channels) + 1
+        st.session_state[SALES_PRODUCT_COUNTER_KEY] = len(unique_products) + 1
+
+
+def _standardize_sales_df(df: pd.DataFrame) -> pd.DataFrame:
+    base = df.copy()
+    base.columns = [str(col).strip() for col in base.columns]
+    if "チャネル" not in base.columns or "商品" not in base.columns:
+        raise ValueError("テンプレートには『チャネル』『商品』列が必要です。")
+    for month_col in MONTH_COLUMNS:
+        if month_col not in base.columns:
+            base[month_col] = 0.0
+    ordered = ["チャネル", "商品", *MONTH_COLUMNS]
+    base = base[ordered]
+    base["チャネル"] = base["チャネル"].fillna("").astype(str)
+    base["商品"] = base["商品"].fillna("").astype(str)
+    for month_col in MONTH_COLUMNS:
+        base[month_col] = (
+            pd.to_numeric(base[month_col], errors="coerce").fillna(0.0).astype(float)
+        )
+    return base
+
+
+def _sales_template_to_csv(df: pd.DataFrame) -> bytes:
+    return df.to_csv(index=False).encode("utf-8-sig")
+
+
+def _sales_template_to_excel(df: pd.DataFrame) -> bytes:
+    buffer = io.BytesIO()
+    with pd.ExcelWriter(buffer, engine="openpyxl") as writer:
+        df.to_excel(writer, sheet_name="SalesTemplate", index=False)
+    buffer.seek(0)
+    return buffer.read()
+
+
+def _load_sales_template_from_upload(upload: io.BytesIO | None) -> pd.DataFrame | None:
+    if upload is None:
+        return None
+    file_size = getattr(upload, "size", None)
+    if file_size is not None and file_size > MAX_UPLOAD_BYTES:
+        st.error("アップロードできるファイルサイズは5MBまでです。")
+        return None
+    mime_type = getattr(upload, "type", "") or ""
+    file_name = getattr(upload, "name", "")
+    extension = Path(str(file_name)).suffix.lower()
+    if mime_type and mime_type not in ALLOWED_MIME_TYPES:
+        st.error("CSVまたはExcel形式のファイルをアップロードしてください。")
+        return None
+    if extension not in ALLOWED_EXTENSIONS:
+        st.error("拡張子が .csv または .xlsx のファイルのみ受け付けます。")
+        return None
+    try:
+        if extension == ".csv":
+            df = pd.read_csv(upload)
+        else:
+            df = pd.read_excel(upload)
+    except Exception:
+        st.error("ファイルの読み込みに失敗しました。書式を確認してください。")
+        return None
+    try:
+        return _standardize_sales_df(df)
+    except ValueError as exc:
+        st.error(str(exc))
+    return None
+
+
+def _yen_number_input(
+    label: str,
+    *,
+    value: float,
+    min_value: float = 0.0,
+    max_value: float | None = None,
+    step: float = 1.0,
+    key: str | None = None,
+) -> float:
+    kwargs = {"min_value": float(min_value), "step": float(step), "value": float(value), "format": "¥%.0f"}
+    if max_value is not None:
+        kwargs["max_value"] = float(max_value)
+    if key is not None:
+        kwargs["key"] = key
+    return float(st.number_input(label, **kwargs))
+
+
+def _percent_number_input(
+    label: str,
+    *,
+    value: float,
+    min_value: float = 0.0,
+    max_value: float = 1.0,
+    step: float = 0.01,
+    key: str | None = None,
+) -> float:
+    kwargs = {
+        "min_value": float(min_value),
+        "max_value": float(max_value),
+        "step": float(step),
+        "value": float(value),
+        "format": "%.2f%%",
+    }
+    if key is not None:
+        kwargs["key"] = key
+    return float(st.number_input(label, **kwargs))
+
+
+def _render_sales_guide_panel() -> None:
+    st.markdown(
+        """
+        <div class="guide-panel" style="background-color:rgba(240,248,255,0.6);padding:1rem;border-radius:0.75rem;">
+            <h4 style="margin-top:0;">💡 入力ガイド</h4>
+            <ul style="padding-left:1.2rem;">
+                <li title="売上＝客数×客単価×購入頻度">売上は <strong>客数×客単価×購入頻度</strong> に分解すると改善ポイントが見えます。</li>
+                <li title="チャネル別の獲得効率を把握">チャネルごとに行を分け、獲得効率や投資対効果を比較しましょう。</li>
+                <li title="商品ライフサイクルに応じた山谷を設定">商品ごとに月別の山谷を設定し、販促や季節性を織り込みます。</li>
+                <li title="テンプレートはCSV/Excelでオフライン編集可能">テンプレートはダウンロードしてオフラインで編集し、同じ形式でアップロードできます。</li>
+            </ul>
+        </div>
+        """,
+        unsafe_allow_html=True,
+    )
 
 def _sales_dataframe(data: Dict) -> pd.DataFrame:
     rows: List[Dict[str, float | str]] = []
@@ -117,7 +257,14 @@ def _loan_dataframe(data: Dict) -> pd.DataFrame:
     return pd.DataFrame(rows)
 
 
-sales_df = _sales_dataframe(finance_raw.get("sales", {}))
+sales_base_df = _sales_dataframe(finance_raw.get("sales", {}))
+_ensure_sales_template_state(sales_base_df)
+stored_sales_df = st.session_state.get(SALES_TEMPLATE_STATE_KEY, sales_base_df)
+try:
+    sales_df = _standardize_sales_df(pd.DataFrame(stored_sales_df))
+except ValueError:
+    sales_df = sales_base_df.copy()
+st.session_state[SALES_TEMPLATE_STATE_KEY] = sales_df
 capex_df = _capex_dataframe(finance_raw.get("capex", {}))
 loan_df = _loan_dataframe(finance_raw.get("loans", {}))
 
@@ -140,16 +287,112 @@ sales_tab, cost_tab, invest_tab, tax_tab = st.tabs(
 
 with sales_tab:
     st.subheader("売上計画：チャネル×商品×月")
-    st.caption("各行はチャネル×商品を表し、12ヶ月の売上高を入力します。単位は円ベースで扱われ、表示単位で丸められます。")
-    sales_df = st.data_editor(
-        sales_df,
-        num_rows="dynamic",
-        use_container_width=True,
-        key="sales_editor",
-    )
-    if any(err.field.startswith("sales") for err in validation_errors):
-        messages = "<br/>".join(err.message for err in validation_errors if err.field.startswith("sales"))
-        st.markdown(f"<div class='field-error'>{messages}</div>", unsafe_allow_html=True)
+    st.caption("各行はチャネル×商品を表し、12ヶ月の売上高を入力します。テンプレートをDL/ULすると、オフライン編集も可能です。")
+
+    main_col, guide_col = st.columns([4, 1], gap="large")
+
+    with main_col:
+        control_cols = st.columns([1.2, 1.8, 1], gap="medium")
+        with control_cols[0]:
+            if st.button("チャネル追加", use_container_width=True, key="add_channel_button"):
+                next_channel_idx = int(st.session_state.get(SALES_CHANNEL_COUNTER_KEY, 1))
+                next_product_idx = int(st.session_state.get(SALES_PRODUCT_COUNTER_KEY, 1))
+                new_row = {
+                    "チャネル": f"新チャネル{next_channel_idx}",
+                    "商品": f"新商品{next_product_idx}",
+                    **{month: 0.0 for month in MONTH_COLUMNS},
+                }
+                st.session_state[SALES_CHANNEL_COUNTER_KEY] = next_channel_idx + 1
+                st.session_state[SALES_PRODUCT_COUNTER_KEY] = next_product_idx + 1
+                updated = pd.concat([sales_df, pd.DataFrame([new_row])], ignore_index=True)
+                st.session_state[SALES_TEMPLATE_STATE_KEY] = _standardize_sales_df(updated)
+                st.toast("新しいチャネル行を追加しました。", icon="➕")
+
+        channel_options = [str(ch) for ch in sales_df["チャネル"].tolist() if str(ch).strip()]
+        if not channel_options:
+            channel_options = [f"新チャネル{int(st.session_state.get(SALES_CHANNEL_COUNTER_KEY, 1))}"]
+        with control_cols[1]:
+            selected_channel = st.selectbox(
+                "商品追加先チャネル",
+                options=channel_options,
+                key="product_channel_select",
+            )
+        with control_cols[2]:
+            if st.button("商品追加", use_container_width=True, key="add_product_button"):
+                next_product_idx = int(st.session_state.get(SALES_PRODUCT_COUNTER_KEY, 1))
+                target_channel = selected_channel or channel_options[0]
+                new_row = {
+                    "チャネル": target_channel,
+                    "商品": f"新商品{next_product_idx}",
+                    **{month: 0.0 for month in MONTH_COLUMNS},
+                }
+                st.session_state[SALES_PRODUCT_COUNTER_KEY] = next_product_idx + 1
+                updated = pd.concat([sales_df, pd.DataFrame([new_row])], ignore_index=True)
+                st.session_state[SALES_TEMPLATE_STATE_KEY] = _standardize_sales_df(updated)
+                st.toast("選択したチャネルに商品行を追加しました。", icon="🆕")
+
+        sales_df = st.session_state[SALES_TEMPLATE_STATE_KEY]
+        month_columns_config = {
+            month: st.column_config.NumberColumn(month, min_value=0.0, step=1.0, format="¥%d")
+            for month in MONTH_COLUMNS
+        }
+        with st.form("sales_template_form"):
+            download_cols = st.columns(2)
+            with download_cols[0]:
+                st.download_button(
+                    "CSVテンプレートDL",
+                    data=_sales_template_to_csv(sales_df),
+                    file_name="sales_template.csv",
+                    mime="text/csv",
+                    use_container_width=True,
+                )
+            with download_cols[1]:
+                st.download_button(
+                    "ExcelテンプレートDL",
+                    data=_sales_template_to_excel(sales_df),
+                    file_name="sales_template.xlsx",
+                    mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                    use_container_width=True,
+                )
+            uploaded_template = st.file_uploader(
+                "テンプレートをアップロード (最大5MB)",
+                type=["csv", "xlsx"],
+                accept_multiple_files=False,
+                help="ダウンロードしたテンプレートと同じ列構成でアップロードしてください。",
+            )
+            edited_df = st.data_editor(
+                sales_df,
+                num_rows="dynamic",
+                use_container_width=True,
+                hide_index=True,
+                column_config={
+                    "チャネル": st.column_config.TextColumn("チャネル", max_chars=40),
+                    "商品": st.column_config.TextColumn("商品", max_chars=40),
+                    **month_columns_config,
+                },
+                key="sales_editor",
+            )
+            if st.form_submit_button("テンプレートを反映", use_container_width=True):
+                if uploaded_template is not None:
+                    loaded_df = _load_sales_template_from_upload(uploaded_template)
+                    if loaded_df is not None:
+                        st.session_state[SALES_TEMPLATE_STATE_KEY] = loaded_df
+                        st.success("アップロードしたテンプレートを適用しました。")
+                else:
+                    st.session_state[SALES_TEMPLATE_STATE_KEY] = _standardize_sales_df(
+                        pd.DataFrame(edited_df)
+                    )
+                    st.success("エディタの内容をテンプレートに反映しました。")
+
+        sales_df = st.session_state[SALES_TEMPLATE_STATE_KEY]
+        if any(err.field.startswith("sales") for err in validation_errors):
+            messages = "<br/>".join(
+                err.message for err in validation_errors if err.field.startswith("sales")
+            )
+            st.markdown(f"<div class='field-error'>{messages}</div>", unsafe_allow_html=True)
+
+    with guide_col:
+        _render_sales_guide_panel()
 
 with cost_tab:
     st.subheader("コスト計画：変動費と固定費")
@@ -159,13 +402,12 @@ with cost_tab:
     variable_inputs: Dict[str, float] = {}
     for col, code, label in zip(var_cols, var_codes, var_labels):
         with col:
-            variable_inputs[code] = st.number_input(
+            variable_inputs[code] = _percent_number_input(
                 f"{label} 原価率",
                 min_value=0.0,
                 max_value=1.0,
                 step=0.005,
                 value=float(variable_ratios.get(code, 0.0)),
-                format="%.3f",
             )
     st.caption("変動費は売上高に対する比率で入力します。0〜1の範囲で設定してください。")
 
@@ -176,12 +418,10 @@ with cost_tab:
     for col, code, label in zip(fixed_cols, fixed_codes, fixed_labels):
         with col:
             base_value = Decimal(str(fixed_costs.get(code, 0.0)))
-            fixed_inputs[code] = st.number_input(
+            fixed_inputs[code] = _yen_number_input(
                 f"{label} ({unit})",
-                min_value=0.0,
-                step=1.0,
                 value=float(base_value / unit_factor),
-                format="%.0f",
+                step=1.0,
             )
     st.caption("固定費は入力した単位で保存されます。")
 
@@ -193,11 +433,10 @@ with cost_tab:
     for col, code, label in zip(noi_cols, noi_codes, noi_labels):
         with col:
             base_value = Decimal(str(noi_defaults.get(code, 0.0)))
-            noi_inputs[code] = st.number_input(
+            noi_inputs[code] = _yen_number_input(
                 f"{label} ({unit})",
-                min_value=0.0,
-                step=1.0,
                 value=float(base_value / unit_factor),
+                step=1.0,
             )
 
     noe_cols = st.columns(2)
@@ -207,11 +446,10 @@ with cost_tab:
     for col, code, label in zip(noe_cols, noe_codes, noe_labels):
         with col:
             base_value = Decimal(str(noe_defaults.get(code, 0.0)))
-            noe_inputs[code] = st.number_input(
+            noe_inputs[code] = _yen_number_input(
                 f"{label} ({unit})",
-                min_value=0.0,
-                step=1.0,
                 value=float(base_value / unit_factor),
+                step=1.0,
             )
 
     if any(err.field.startswith("costs") for err in validation_errors):
@@ -226,7 +464,9 @@ with invest_tab:
         num_rows="dynamic",
         use_container_width=True,
         column_config={
-            "金額": st.column_config.NumberColumn("金額 (円)", min_value=0.0, step=1_000_000.0, format="%.0f"),
+            "金額": st.column_config.NumberColumn(
+                "金額 (円)", min_value=0.0, step=1_000_000.0, format="¥%d"
+            ),
             "開始月": st.column_config.NumberColumn("開始月", min_value=1, max_value=12, step=1),
             "耐用年数": st.column_config.NumberColumn("耐用年数 (年)", min_value=1, max_value=20, step=1),
         },
@@ -239,8 +479,12 @@ with invest_tab:
         num_rows="dynamic",
         use_container_width=True,
         column_config={
-            "元本": st.column_config.NumberColumn("元本 (円)", min_value=0.0, step=1_000_000.0, format="%.0f"),
-            "金利": st.column_config.NumberColumn("金利", min_value=0.0, max_value=0.2, step=0.001, format="%.3f"),
+            "元本": st.column_config.NumberColumn(
+                "元本 (円)", min_value=0.0, step=1_000_000.0, format="¥%d"
+            ),
+            "金利": st.column_config.NumberColumn(
+                "金利", min_value=0.0, max_value=0.2, step=0.001, format="%.2f%%"
+            ),
             "返済期間(月)": st.column_config.NumberColumn("返済期間 (月)", min_value=1, max_value=600, step=1),
             "開始月": st.column_config.NumberColumn("開始月", min_value=1, max_value=12, step=1),
             "返済タイプ": st.column_config.SelectboxColumn("返済タイプ", options=["equal_principal", "interest_only"]),
@@ -258,29 +502,26 @@ with invest_tab:
 with tax_tab:
     st.subheader("税制・備考")
     tax_defaults = finance_raw.get("tax", {})
-    corporate_rate = st.number_input(
+    corporate_rate = _percent_number_input(
         "法人税率 (0-55%)",
         min_value=0.0,
         max_value=0.55,
         step=0.01,
         value=float(tax_defaults.get("corporate_tax_rate", 0.3)),
-        format="%.2f",
     )
-    consumption_rate = st.number_input(
+    consumption_rate = _percent_number_input(
         "消費税率 (0-20%)",
         min_value=0.0,
         max_value=0.20,
         step=0.01,
         value=float(tax_defaults.get("consumption_tax_rate", 0.1)),
-        format="%.2f",
     )
-    dividend_ratio = st.number_input(
+    dividend_ratio = _percent_number_input(
         "配当性向",
         min_value=0.0,
         max_value=1.0,
         step=0.05,
         value=float(tax_defaults.get("dividend_payout_ratio", 0.0)),
-        format="%.2f",
     )
 
     st.caption("税率は自動でバリデーションされます。")
@@ -293,9 +534,12 @@ with tax_tab:
 save_col, summary_col = st.columns([2, 1])
 with save_col:
     if st.button("入力を検証して保存", type="primary"):
+        sales_df = _standardize_sales_df(pd.DataFrame(st.session_state[SALES_TEMPLATE_STATE_KEY]))
+        st.session_state[SALES_TEMPLATE_STATE_KEY] = sales_df
+
         sales_data = {"items": []}
         for _, row in sales_df.fillna(0).iterrows():
-            monthly_amounts = [Decimal(str(row[f"月{m:02d}"])) for m in MONTH_SEQUENCE]
+            monthly_amounts = [Decimal(str(row[month])) for month in MONTH_COLUMNS]
             sales_data["items"].append(
                 {
                     "channel": str(row.get("チャネル", "")).strip() or "未設定",
@@ -387,7 +631,7 @@ with save_col:
 
 with summary_col:
     total_sales = sum(
-        Decimal(str(row[f"月{m:02d}"])) for _, row in sales_df.iterrows() for m in MONTH_SEQUENCE
+        Decimal(str(row[month])) for _, row in sales_df.iterrows() for month in MONTH_COLUMNS
     )
     avg_ratio = sum(variable_inputs.values()) / len(variable_inputs) if variable_inputs else 0.0
     st.metric("売上合計", format_amount_with_unit(total_sales, unit))

--- a/pages/20_Analysis.py
+++ b/pages/20_Analysis.py
@@ -2,10 +2,12 @@
 from __future__ import annotations
 
 from decimal import Decimal
-from typing import Dict, List
+from typing import Dict, List, Tuple
 
-import altair as alt
+import numpy as np
 import pandas as pd
+import plotly.graph_objects as go
+from plotly.subplots import make_subplots
 import streamlit as st
 
 from calc import (
@@ -19,6 +21,232 @@ from calc import (
 from formatting import format_amount_with_unit, format_ratio
 from state import ensure_session_defaults, load_finance_bundle
 from theme import inject_theme
+
+ITEM_LABELS = {code: label for code, label, _ in ITEMS}
+
+
+def _to_decimal(value: object) -> Decimal:
+    return Decimal(str(value))
+
+
+@st.cache_data(show_spinner=False)
+def build_monthly_pl_dataframe(
+    sales_data: Dict[str, object],
+    plan_items: Dict[str, Dict[str, str]],
+    amounts_data: Dict[str, str],
+) -> pd.DataFrame:
+    monthly_sales = {month: Decimal("0") for month in range(1, 13)}
+    for item in sales_data.get("items", []):
+        monthly = item.get("monthly", {})
+        amounts = monthly.get("amounts", [])
+        for idx, month in enumerate(range(1, 13)):
+            value = amounts[idx] if idx < len(amounts) else 0
+            monthly_sales[month] += _to_decimal(value)
+
+    total_sales = _to_decimal(amounts_data.get("REV", "0"))
+    total_gross = _to_decimal(amounts_data.get("GROSS", "0"))
+    gross_ratio = total_gross / total_sales if total_sales else Decimal("0")
+
+    rows: List[Dict[str, float]] = []
+    for month in range(1, 13):
+        sales = monthly_sales.get(month, Decimal("0"))
+        monthly_gross = sales * gross_ratio
+        cogs = Decimal("0")
+        opex = Decimal("0")
+        for code, cfg in plan_items.items():
+            method = str(cfg.get("method", ""))
+            base = str(cfg.get("rate_base", "sales"))
+            value = _to_decimal(cfg.get("value", "0"))
+            if not code.startswith(("COGS", "OPEX")):
+                continue
+            if method == "rate":
+                if base == "gross":
+                    amount = monthly_gross * value
+                elif base == "sales":
+                    amount = sales * value
+                else:
+                    amount = value
+            else:
+                amount = value / Decimal("12")
+            if code.startswith("COGS"):
+                cogs += amount
+            else:
+                opex += amount
+        gross = sales - cogs
+        op = gross - opex
+        gross_margin = gross / sales if sales else Decimal("0")
+        rows.append(
+            {
+                "month": f"{month}月",
+                "売上高": float(sales),
+                "売上原価": float(cogs),
+                "販管費": float(opex),
+                "営業利益": float(op),
+                "粗利": float(gross),
+                "粗利率": float(gross_margin),
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+@st.cache_data(show_spinner=False)
+def build_cost_composition(amounts_data: Dict[str, str]) -> pd.DataFrame:
+    component_codes = [
+        "COGS_MAT",
+        "COGS_LBR",
+        "COGS_OUT_SRC",
+        "COGS_OUT_CON",
+        "COGS_OTH",
+        "OPEX_H",
+        "OPEX_K",
+        "OPEX_DEP",
+        "NOE_INT",
+        "NOE_OTH",
+    ]
+    rows: List[Dict[str, float]] = []
+    for code in component_codes:
+        value = _to_decimal(amounts_data.get(code, "0"))
+        if value <= 0:
+            continue
+        rows.append({"項目": ITEM_LABELS.get(code, code), "金額": float(value)})
+    return pd.DataFrame(rows)
+
+
+def _cost_structure(
+    plan_items: Dict[str, Dict[str, str]], amounts_data: Dict[str, str]
+) -> Tuple[Decimal, Decimal]:
+    sales_total = _to_decimal(amounts_data.get("REV", "0"))
+    gross_total = _to_decimal(amounts_data.get("GROSS", "0"))
+    variable_cost = Decimal("0")
+    fixed_cost = Decimal("0")
+    for cfg in plan_items.values():
+        method = str(cfg.get("method", ""))
+        base = str(cfg.get("rate_base", "sales"))
+        value = _to_decimal(cfg.get("value", "0"))
+        if method == "rate":
+            if base == "gross":
+                ratio = gross_total / sales_total if sales_total else Decimal("0")
+                variable_cost += sales_total * (value * ratio)
+            elif base == "sales":
+                variable_cost += sales_total * value
+            elif base == "fixed":
+                fixed_cost += value
+        else:
+            fixed_cost += value
+    variable_rate = variable_cost / sales_total if sales_total else Decimal("0")
+    return variable_rate, fixed_cost
+
+
+@st.cache_data(show_spinner=False)
+def build_cvp_dataframe(
+    plan_items: Dict[str, Dict[str, str]], amounts_data: Dict[str, str]
+) -> Tuple[pd.DataFrame, Decimal, Decimal, Decimal]:
+    variable_rate, fixed_cost = _cost_structure(plan_items, amounts_data)
+    sales_total = _to_decimal(amounts_data.get("REV", "0"))
+    max_sales = sales_total * Decimal("1.3") if sales_total else Decimal("1000000")
+    max_sales_float = max(float(max_sales), float(sales_total)) if sales_total else float(max_sales)
+    sales_values = np.linspace(0, max_sales_float if max_sales_float > 0 else 1.0, 40)
+    rows: List[Dict[str, float]] = []
+    for sale in sales_values:
+        sale_decimal = _to_decimal(sale)
+        total_cost = fixed_cost + variable_rate * sale_decimal
+        rows.append(
+            {
+                "売上高": float(sale_decimal),
+                "総費用": float(total_cost),
+            }
+        )
+    breakeven = _to_decimal(amounts_data.get("BE_SALES", "0"))
+    return pd.DataFrame(rows), variable_rate, fixed_cost, breakeven
+
+
+@st.cache_data(show_spinner=False)
+def build_fcf_steps(
+    amounts_data: Dict[str, str],
+    tax_data: Dict[str, object],
+    capex_data: Dict[str, object],
+    loans_data: Dict[str, object],
+) -> List[Dict[str, float]]:
+    del loans_data  # 不要だがインターフェイスを合わせる
+    ebit = _to_decimal(amounts_data.get("OP", "0"))
+    corporate_rate = _to_decimal(tax_data.get("corporate_tax_rate", "0"))
+    taxes = ebit * corporate_rate if ebit > 0 else Decimal("0")
+    depreciation = _to_decimal(amounts_data.get("OPEX_DEP", "0"))
+    working_capital = Decimal("0")
+    capex_total = sum(
+        (_to_decimal(item.get("amount", "0")) for item in capex_data.get("items", [])),
+        start=Decimal("0"),
+    )
+    fcf = ebit - taxes + depreciation - working_capital - capex_total
+    return [
+        {"name": "EBIT", "value": float(ebit)},
+        {"name": "税金", "value": float(-taxes)},
+        {"name": "減価償却", "value": float(depreciation)},
+        {"name": "運転資本", "value": float(-working_capital)},
+        {"name": "CAPEX", "value": float(-capex_total)},
+        {"name": "FCF", "value": float(fcf)},
+    ]
+
+
+@st.cache_data(show_spinner=False)
+def build_dscr_timeseries(
+    loans_data: Dict[str, object], operating_cf_value: str
+) -> pd.DataFrame:
+    operating_cf = _to_decimal(operating_cf_value)
+    if operating_cf < 0:
+        operating_cf = Decimal("0")
+    records: List[Dict[str, object]] = []
+    for loan in loans_data.get("loans", []):
+        principal = _to_decimal(loan.get("principal", "0"))
+        rate = _to_decimal(loan.get("interest_rate", "0"))
+        term_months = int(loan.get("term_months", 0))
+        start_month = int(loan.get("start_month", 1))
+        repayment_type = str(loan.get("repayment_type", "equal_principal"))
+        if term_months <= 0 or principal <= 0:
+            continue
+        outstanding = principal
+        for offset in range(term_months):
+            month_index = start_month + offset
+            year_index = (month_index - 1) // 12 + 1
+            interest = outstanding * rate / Decimal("12")
+            if repayment_type == "equal_principal":
+                principal_payment = principal / Decimal(term_months)
+            else:
+                principal_payment = principal if offset == term_months - 1 else Decimal("0")
+            principal_payment = min(principal_payment, outstanding)
+            ending = outstanding - principal_payment
+            records.append(
+                {
+                    "year": year_index,
+                    "interest": interest,
+                    "principal": principal_payment,
+                    "out_start": outstanding,
+                    "out_end": ending,
+                }
+            )
+            outstanding = ending
+
+    if not records:
+        return pd.DataFrame()
+
+    grouped_rows: List[Dict[str, float]] = []
+    for year, group in pd.DataFrame(records).groupby("year"):
+        interest_total = sum(group["interest"], start=Decimal("0"))
+        principal_total = sum(group["principal"], start=Decimal("0"))
+        outstanding_start = group["out_start"].iloc[0]
+        debt_service = interest_total + principal_total
+        dscr = operating_cf / debt_service if debt_service > 0 else Decimal("NaN")
+        payback_years = (
+            outstanding_start / operating_cf if operating_cf > 0 else Decimal("NaN")
+        )
+        grouped_rows.append(
+            {
+                "年度": f"FY{year}",
+                "DSCR": float(dscr),
+                "債務償還年数": float(payback_years),
+            }
+        )
+    return pd.DataFrame(grouped_rows)
 
 st.set_page_config(
     page_title="経営計画スタジオ｜Analysis",
@@ -53,6 +281,29 @@ metrics = summarize_plan_metrics(amounts)
 bs_data = generate_balance_sheet(amounts, bundle.capex, bundle.loans, bundle.tax)
 cf_data = generate_cash_flow(amounts, bundle.capex, bundle.loans, bundle.tax)
 
+plan_items_serialized = {
+    code: {
+        "method": str(cfg.get("method", "")),
+        "rate_base": str(cfg.get("rate_base", "sales")),
+        "value": str(cfg.get("value", "0")),
+    }
+    for code, cfg in plan_cfg.items.items()
+}
+sales_dump = bundle.sales.model_dump(mode="json")
+amounts_serialized = {code: str(value) for code, value in amounts.items()}
+capex_dump = bundle.capex.model_dump(mode="json")
+loans_dump = bundle.loans.model_dump(mode="json")
+tax_dump = bundle.tax.model_dump(mode="json")
+
+monthly_pl_df = build_monthly_pl_dataframe(sales_dump, plan_items_serialized, amounts_serialized)
+cost_df = build_cost_composition(amounts_serialized)
+cvp_df, variable_rate, fixed_cost, breakeven_sales = build_cvp_dataframe(
+    plan_items_serialized, amounts_serialized
+)
+fcf_steps = build_fcf_steps(amounts_serialized, tax_dump, capex_dump, loans_dump)
+operating_cf_str = str(cf_data.get("営業キャッシュフロー", Decimal("0")))
+dscr_df = build_dscr_timeseries(loans_dump, operating_cf_str)
+
 st.title("📈 KPI・損益分析")
 st.caption(f"FY{fiscal_year} / 表示単位: {unit} / FTE: {fte}")
 
@@ -71,54 +322,185 @@ with kpi_tab:
     ratio_cols[1].metric("営業利益率", format_ratio(metrics.get("op_margin")))
     ratio_cols[2].metric("経常利益率", format_ratio(metrics.get("ord_margin")))
 
-    st.markdown("### PLサマリー")
+    monthly_pl_fig = go.Figure()
+    monthly_pl_fig.add_trace(
+        go.Bar(
+            name='売上原価',
+            x=monthly_pl_df['month'],
+            y=monthly_pl_df['売上原価'],
+            marker_color='#FF9F43',
+            hovertemplate='月=%{x}<br>売上原価=¥%{y:,.0f}<extra></extra>',
+        )
+    )
+    monthly_pl_fig.add_trace(
+        go.Bar(
+            name='販管費',
+            x=monthly_pl_df['month'],
+            y=monthly_pl_df['販管費'],
+            marker_color='#636EFA',
+            hovertemplate='月=%{x}<br>販管費=¥%{y:,.0f}<extra></extra>',
+        )
+    )
+    monthly_pl_fig.add_trace(
+        go.Bar(
+            name='営業利益',
+            x=monthly_pl_df['month'],
+            y=monthly_pl_df['営業利益'],
+            marker_color='#00CC96',
+            hovertemplate='月=%{x}<br>営業利益=¥%{y:,.0f}<extra></extra>',
+        )
+    )
+    monthly_pl_fig.add_trace(
+        go.Scatter(
+            name='売上高',
+            x=monthly_pl_df['month'],
+            y=monthly_pl_df['売上高'],
+            mode='lines+markers',
+            line=dict(color='#EF553B', width=3),
+            hovertemplate='月=%{x}<br>売上高=¥%{y:,.0f}<extra></extra>',
+        )
+    )
+    monthly_pl_fig.update_layout(
+        barmode='stack',
+        hovermode='x unified',
+        legend_title_text='',
+        yaxis_title='金額 (円)',
+        yaxis_tickformat=',',
+    )
+
+    st.markdown('### 月次PL（スタック棒）')
+    st.plotly_chart(monthly_pl_fig, use_container_width=True)
+
+    trend_cols = st.columns(2)
+    with trend_cols[0]:
+        margin_fig = go.Figure()
+        margin_fig.add_trace(
+            go.Scatter(
+                x=monthly_pl_df['month'],
+                y=(monthly_pl_df['粗利率'] * 100).round(4),
+                mode='lines+markers',
+                name='粗利率',
+                line=dict(color='#AB63FA'),
+                hovertemplate='月=%{x}<br>粗利率=%{y:.1f}%<extra></extra>',
+            )
+        )
+        margin_fig.update_layout(
+            hovermode='x unified',
+            yaxis_title='粗利率 (%)',
+            yaxis_ticksuffix='%',
+            legend_title_text='',
+        )
+        st.markdown('#### 粗利率推移')
+        st.plotly_chart(margin_fig, use_container_width=True)
+
+    with trend_cols[1]:
+        st.markdown('#### 費用構成ドーナツ')
+        if not cost_df.empty:
+            cost_fig = go.Figure(
+                go.Pie(
+                    labels=cost_df['項目'],
+                    values=cost_df['金額'],
+                    hole=0.55,
+                    textinfo='label+percent',
+                    hovertemplate='%{label}: ¥%{value:,.0f}<extra></extra>',
+                )
+            )
+            cost_fig.update_layout(legend_title_text='')
+            st.plotly_chart(cost_fig, use_container_width=True)
+        else:
+            st.info('費用構成を表示するデータがありません。')
+
+    st.markdown('### FCFウォーターフォール')
+    fcf_labels = [step['name'] for step in fcf_steps]
+    fcf_values = [step['value'] for step in fcf_steps]
+    fcf_measures = ['relative'] * (len(fcf_values) - 1) + ['total']
+    fcf_fig = go.Figure(
+        go.Waterfall(
+            name='FCF',
+            orientation='v',
+            measure=fcf_measures,
+            x=fcf_labels,
+            y=fcf_values,
+            text=[f"¥{value:,.0f}" for value in fcf_values],
+            hovertemplate='%{x}: ¥%{y:,.0f}<extra></extra>',
+        )
+    )
+    fcf_fig.update_layout(showlegend=False, yaxis_title='金額 (円)')
+    st.plotly_chart(fcf_fig, use_container_width=True)
+
+    st.markdown('### PLサマリー')
     pl_rows: List[Dict[str, object]] = []
     for code, label, group in ITEMS:
-        if code in {"BE_SALES", "PC_SALES", "PC_GROSS", "PC_ORD", "LDR"}:
+        if code in {'BE_SALES', 'PC_SALES', 'PC_GROSS', 'PC_ORD', 'LDR'}:
             continue
-        value = amounts.get(code, Decimal("0"))
-        pl_rows.append({"カテゴリ": group, "項目": label, "金額": float(value)})
+        value = amounts.get(code, Decimal('0'))
+        pl_rows.append({'カテゴリ': group, '項目': label, '金額': float(value)})
     pl_df = pd.DataFrame(pl_rows)
     st.dataframe(pl_df, use_container_width=True, hide_index=True)
-
-    st.markdown("### コスト構成比")
-    cost_codes = ["COGS_MAT", "COGS_LBR", "COGS_OUT_SRC", "COGS_OUT_CON", "COGS_OTH", "OPEX_H", "OPEX_K", "OPEX_DEP"]
-    cost_rows = []
-    revenue = amounts.get("REV", Decimal("0"))
-    for code in cost_codes:
-        label = next((lbl for item_code, lbl, _ in ITEMS if item_code == code), code)
-        value = amounts.get(code, Decimal("0"))
-        ratio = float((value / revenue) * Decimal("100")) if revenue > 0 else 0.0
-        cost_rows.append({"項目": label, "金額": float(value), "売上比%": ratio})
-    cost_df = pd.DataFrame(cost_rows)
-    if not cost_df.empty:
-        chart = (
-            alt.Chart(cost_df)
-            .mark_bar()
-            .encode(
-                x=alt.X("売上比%:Q", title="売上比率 (%)"),
-                y=alt.Y("項目:N", sort="-x"),
-                tooltip=["項目", alt.Tooltip("金額:Q", title="金額", format=","), alt.Tooltip("売上比%:Q", title="売上比", format=".1f")],
-            )
-            .properties(height=max(240, 20 * len(cost_df)))
-        )
-        st.altair_chart(chart, use_container_width=True)
-    else:
-        st.caption("コストデータが未設定です。")
 
 with be_tab:
     st.subheader("損益分岐点分析")
     be_sales = metrics.get("breakeven", Decimal("0"))
     sales = amounts.get("REV", Decimal("0"))
-    ratio = (be_sales / sales) if sales > 0 else Decimal("0")
+    if isinstance(be_sales, Decimal) and be_sales.is_finite() and sales > 0:
+        ratio = be_sales / sales
+    else:
+        ratio = Decimal("0")
+    safety_margin = Decimal("1") - ratio if sales > 0 else Decimal("0")
 
     info_cols = st.columns(3)
     info_cols[0].metric("損益分岐点売上高", format_amount_with_unit(be_sales, unit))
     info_cols[1].metric("現在の売上高", format_amount_with_unit(sales, unit))
-    info_cols[2].metric("安全余裕度", format_ratio(Decimal("1") - ratio if sales > 0 else Decimal("0")))
+    info_cols[2].metric("安全余裕度", format_ratio(safety_margin))
 
-    st.progress(min(max(float(1 - ratio), 0.0), 1.0), "安全余裕度")
+    st.progress(min(max(float(safety_margin), 0.0), 1.0), "安全余裕度")
     st.caption("進捗バーは売上高が損益分岐点をどの程度上回っているかを可視化します。")
+
+    cvp_fig = go.Figure()
+    cvp_fig.add_trace(
+        go.Scatter(
+            name='売上線',
+            x=cvp_df['売上高'],
+            y=cvp_df['売上高'],
+            mode='lines',
+            line=dict(color='#636EFA'),
+            hovertemplate='売上高=¥%{x:,.0f}<extra></extra>',
+        )
+    )
+    cvp_fig.add_trace(
+        go.Scatter(
+            name='総費用線',
+            x=cvp_df['売上高'],
+            y=cvp_df['総費用'],
+            mode='lines',
+            line=dict(color='#EF553B'),
+            hovertemplate='売上高=¥%{x:,.0f}<br>総費用=¥%{y:,.0f}<extra></extra>',
+        )
+    )
+    if isinstance(breakeven_sales, Decimal) and breakeven_sales.is_finite() and breakeven_sales > 0:
+        be_value = float(breakeven_sales)
+        cvp_fig.add_trace(
+            go.Scatter(
+                name='損益分岐点',
+                x=[be_value],
+                y=[be_value],
+                mode='markers',
+                marker=dict(color='#00CC96', size=12, symbol='diamond'),
+                hovertemplate='損益分岐点=¥%{x:,.0f}<extra></extra>',
+            )
+        )
+    cvp_fig.update_layout(
+        xaxis_title='売上高 (円)',
+        yaxis_title='金額 (円)',
+        hovermode='x unified',
+        legend_title_text='',
+    )
+
+    st.markdown('### CVPチャート')
+    st.plotly_chart(cvp_fig, use_container_width=True)
+    st.caption(
+        f"変動費率: {format_ratio(variable_rate)} ／ 固定費: {format_amount_with_unit(fixed_cost, unit)}"
+    )
 
     st.markdown("### バランスシートのスナップショット")
     bs_rows = []
@@ -134,17 +516,47 @@ with cash_tab:
     cf_df = pd.DataFrame(cf_rows)
     st.dataframe(cf_df, use_container_width=True, hide_index=True)
 
-    chart = (
-        alt.Chart(cf_df)
-        .mark_bar()
-        .encode(
-            x=alt.X("区分:N", sort=None),
-            y=alt.Y("金額:Q", title="金額", axis=alt.Axis(format="~s")),
-            color=alt.Color("区分:N", legend=None),
-            tooltip=["区分", alt.Tooltip("金額:Q", title="金額", format=",")],
+    cf_fig = go.Figure(
+        go.Bar(
+            x=cf_df['区分'],
+            y=cf_df['金額'],
+            marker_color='#636EFA',
+            hovertemplate='%{x}: ¥%{y:,.0f}<extra></extra>',
         )
-        .properties(height=280)
     )
-    st.altair_chart(chart, use_container_width=True)
+    cf_fig.update_layout(showlegend=False, yaxis_title='金額 (円)')
+    st.plotly_chart(cf_fig, use_container_width=True)
+
+    st.markdown('### DSCR / 債務償還年数')
+    if not dscr_df.empty:
+        dscr_fig = make_subplots(specs=[[{'secondary_y': True}]])
+        dscr_fig.add_trace(
+            go.Scatter(
+                x=dscr_df['年度'],
+                y=dscr_df['DSCR'],
+                name='DSCR',
+                mode='lines+markers',
+                line=dict(color='#636EFA'),
+                hovertemplate='%{x}: %{y:.2f}x<extra></extra>',
+            ),
+            secondary_y=False,
+        )
+        dscr_fig.add_trace(
+            go.Scatter(
+                x=dscr_df['年度'],
+                y=dscr_df['債務償還年数'],
+                name='債務償還年数',
+                mode='lines+markers',
+                line=dict(color='#EF553B'),
+                hovertemplate='%{x}: %{y:.1f}年<extra></extra>',
+            ),
+            secondary_y=True,
+        )
+        dscr_fig.update_yaxes(title_text='DSCR (倍)', secondary_y=False)
+        dscr_fig.update_yaxes(title_text='債務償還年数 (年)', secondary_y=True)
+        dscr_fig.update_layout(hovermode='x unified', legend_title_text='')
+        st.plotly_chart(dscr_fig, use_container_width=True)
+    else:
+        st.info('借入データが未登録のため、DSCRを算出できません。')
 
     st.caption("営業CFには減価償却費を足し戻し、税引後利益を反映しています。投資CFはCapex、財務CFは利息支払を表します。")


### PR DESCRIPTION
## Summary
- add stateful monthly sales template helpers so users can download/upload CSV or Excel, validate uploads, and append channel/product rows from dedicated buttons in the input hub
- standardize monetary and ratio controls with ¥/% formatting, refresh investment and tax editors, and surface a tooltip guide panel beside the sales editor
- replace KPI visuals with Plotly charts for monthly PL, cost structure, CVP, FCF waterfall, and DSCR trends while caching data preparation for faster redraws

## Testing
- python -m compileall pages/10_Inputs.py pages/20_Analysis.py

------
https://chatgpt.com/codex/tasks/task_e_68cea8f5f6d08323a849b1d58e3dcbf5