### PR TITLE
Add onboarding sample dataset and loader

### DIFF
--- a/pages/10_Inputs.py
+++ b/pages/10_Inputs.py
@@ -18,6 +18,7 @@ from models import (
     DEFAULT_TAX_POLICY,
     MONTH_SEQUENCE,
 )
+from sample_data import SAMPLE_FISCAL_YEAR, sample_sales_csv_bytes, sample_sales_excel_bytes
 from state import ensure_session_defaults
 from theme import inject_theme
 from validators import ValidationIssue, validate_bundle
@@ -281,6 +282,9 @@ unit_factor = UNIT_FACTORS.get(unit, Decimal("1"))
 st.title("🧾 データ入力ハブ")
 st.caption("売上からコスト、投資、借入、税制までを一箇所で整理します。保存すると全ページに反映されます。")
 
+if st.session_state.get("sample_data_loaded"):
+    st.success("サンプルデータを基に入力が設定されています。自社データに差し替えて保存しましょう。")
+
 sales_tab, cost_tab, invest_tab, tax_tab = st.tabs(
     ["売上計画", "コスト計画", "投資・借入", "税制・メモ"]
 )
@@ -393,6 +397,24 @@ with sales_tab:
 
     with guide_col:
         _render_sales_guide_panel()
+        st.markdown("#### サンプルデータ")
+        st.caption("カテゴリ別売上・数量・月度（YYYY-MM）を含むCSV/XLSXをダウンロードできます。")
+        st.download_button(
+            "CSVサンプルDL",
+            data=sample_sales_csv_bytes(),
+            file_name=f"sample_sales_{SAMPLE_FISCAL_YEAR}.csv",
+            mime="text/csv",
+            use_container_width=True,
+            key="sample_csv_download_inputs",
+        )
+        st.download_button(
+            "ExcelサンプルDL",
+            data=sample_sales_excel_bytes(),
+            file_name=f"sample_sales_{SAMPLE_FISCAL_YEAR}.xlsx",
+            mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            use_container_width=True,
+            key="sample_excel_download_inputs",
+        )
 
 with cost_tab:
     st.subheader("コスト計画：変動費と固定費")
@@ -627,6 +649,7 @@ with save_col:
                 "loans": bundle.loans,
                 "tax": bundle.tax,
             }
+            st.session_state["sample_data_loaded"] = False
             st.toast("財務データを保存しました。", icon="✅")
 
 with summary_col:

--- a/sample_data.py
+++ b/sample_data.py
@@ -1,0 +1,323 @@
+"""Utilities and fixtures for bundled onboarding sample data."""
+from __future__ import annotations
+
+import io
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Dict, Iterable, List
+
+import pandas as pd
+import streamlit as st
+
+from models import (
+    MONTH_SEQUENCE,
+    CapexItem,
+    CapexPlan,
+    CostPlan,
+    FinanceBundle,
+    LoanItem,
+    LoanSchedule,
+    MonthlySeries,
+    SalesItem,
+    SalesPlan,
+    TaxPolicy,
+)
+
+SAMPLE_FISCAL_YEAR = 2025
+
+
+@dataclass(frozen=True)
+class SampleSalesSpec:
+    """Definition of a sample sales stream."""
+
+    channel: str
+    category: str
+    product: str
+    unit_price: Decimal
+    monthly_quantity: List[int]
+
+    def monthly_revenue(self) -> List[Decimal]:
+        return [self.unit_price * Decimal(qty) for qty in self.monthly_quantity]
+
+
+def _as_decimal(value: int | float | Decimal) -> Decimal:
+    return Decimal(str(value))
+
+
+SAMPLE_SALES_SPECS: List[SampleSalesSpec] = [
+    SampleSalesSpec(
+        channel="オンライン直販",
+        category="SaaS",  # クラウド型の主力プロダクト
+        product="成長プラン (月額)",
+        unit_price=_as_decimal(120000),
+        monthly_quantity=[
+            110,
+            118,
+            125,
+            132,
+            140,
+            148,
+            155,
+            162,
+            170,
+            178,
+            186,
+            195,
+        ],
+    ),
+    SampleSalesSpec(
+        channel="オンライン直販",
+        category="SaaS",
+        product="ライトプラン (月額)",
+        unit_price=_as_decimal(45000),
+        monthly_quantity=[
+            220,
+            228,
+            240,
+            252,
+            260,
+            268,
+            280,
+            292,
+            300,
+            312,
+            324,
+            336,
+        ],
+    ),
+    SampleSalesSpec(
+        channel="フィールドセールス",
+        category="エンタープライズ",
+        product="エンタープライズ契約",
+        unit_price=_as_decimal(900000),
+        monthly_quantity=[
+            6,
+            6,
+            7,
+            7,
+            8,
+            8,
+            9,
+            9,
+            10,
+            10,
+            10,
+            11,
+        ],
+    ),
+    SampleSalesSpec(
+        channel="パートナー販売",
+        category="導入支援",
+        product="導入パッケージ",
+        unit_price=_as_decimal(320000),
+        monthly_quantity=[
+            18,
+            18,
+            19,
+            20,
+            21,
+            22,
+            23,
+            24,
+            25,
+            26,
+            27,
+            28,
+        ],
+    ),
+]
+
+
+def _build_sales_plan() -> SalesPlan:
+    items: List[SalesItem] = []
+    for spec in SAMPLE_SALES_SPECS:
+        monthly = MonthlySeries(amounts=[Decimal(amount) for amount in spec.monthly_revenue()])
+        items.append(
+            SalesItem(
+                channel=spec.channel,
+                product=spec.product,
+                monthly=monthly,
+            )
+        )
+    return SalesPlan(items=items)
+
+
+def _build_cost_plan() -> CostPlan:
+    return CostPlan(
+        variable_ratios={
+            "COGS_MAT": Decimal("0.18"),
+            "COGS_LBR": Decimal("0.08"),
+            "COGS_OUT_SRC": Decimal("0.05"),
+            "COGS_OUT_CON": Decimal("0.02"),
+            "COGS_OTH": Decimal("0.01"),
+        },
+        fixed_costs={
+            "OPEX_H": Decimal("130000000"),
+            "OPEX_K": Decimal("360000000"),
+            "OPEX_DEP": Decimal("24000000"),
+        },
+        non_operating_income={"NOI_MISC": Decimal("6000000")},
+        non_operating_expenses={"NOE_INT": Decimal("12000000")},
+    )
+
+
+def _build_capex_plan() -> CapexPlan:
+    return CapexPlan(
+        items=[
+            CapexItem(
+                name="データセンター増強",
+                amount=Decimal("85000000"),
+                start_month=4,
+                useful_life_years=5,
+            ),
+            CapexItem(
+                name="営業支援ツール",
+                amount=Decimal("18000000"),
+                start_month=1,
+                useful_life_years=3,
+            ),
+        ]
+    )
+
+
+def _build_loan_schedule() -> LoanSchedule:
+    return LoanSchedule(
+        loans=[
+            LoanItem(
+                name="成長投資ローン",
+                principal=Decimal("125000000"),
+                interest_rate=Decimal("0.012"),
+                term_months=60,
+                start_month=1,
+                repayment_type="equal_principal",
+            ),
+            LoanItem(
+                name="設備投資ローン",
+                principal=Decimal("60000000"),
+                interest_rate=Decimal("0.009"),
+                term_months=84,
+                start_month=3,
+                repayment_type="interest_only",
+            ),
+        ]
+    )
+
+
+def _build_tax_policy() -> TaxPolicy:
+    return TaxPolicy(
+        corporate_tax_rate=Decimal("0.30"),
+        consumption_tax_rate=Decimal("0.10"),
+        dividend_payout_ratio=Decimal("0.12"),
+    )
+
+
+def create_sample_bundle() -> FinanceBundle:
+    """Return a finance bundle populated with sample fixtures."""
+
+    return FinanceBundle(
+        sales=_build_sales_plan(),
+        costs=_build_cost_plan(),
+        capex=_build_capex_plan(),
+        loans=_build_loan_schedule(),
+        tax=_build_tax_policy(),
+    )
+
+
+def sample_finance_raw() -> Dict[str, Dict]:
+    """Return the sample bundle serialised to raw dictionaries."""
+
+    bundle = create_sample_bundle()
+    return {
+        "sales": bundle.sales.model_dump(),
+        "costs": bundle.costs.model_dump(),
+        "capex": bundle.capex.model_dump(),
+        "loans": bundle.loans.model_dump(),
+        "tax": bundle.tax.model_dump(),
+    }
+
+
+def _sales_template_dataframe() -> pd.DataFrame:
+    rows: List[Dict[str, float | str]] = []
+    for spec in SAMPLE_SALES_SPECS:
+        row: Dict[str, float | str] = {"チャネル": spec.channel, "商品": spec.product}
+        monthly_revenue = spec.monthly_revenue()
+        for idx, month in enumerate(MONTH_SEQUENCE):
+            row[f"月{month:02d}"] = float(monthly_revenue[idx])
+        rows.append(row)
+    return pd.DataFrame(rows)
+
+
+def _sales_tidy_dataframe() -> pd.DataFrame:
+    rows: List[Dict[str, float | str | int]] = []
+    for spec in SAMPLE_SALES_SPECS:
+        monthly_revenue = spec.monthly_revenue()
+        for idx, month in enumerate(MONTH_SEQUENCE, start=0):
+            rows.append(
+                {
+                    "チャネル": spec.channel,
+                    "カテゴリ": spec.category,
+                    "商品": spec.product,
+                    "月度": f"{SAMPLE_FISCAL_YEAR}-{month:02d}",
+                    "数量": int(spec.monthly_quantity[idx]),
+                    "単価": float(spec.unit_price),
+                    "売上高": float(monthly_revenue[idx]),
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def sample_sales_csv_bytes() -> bytes:
+    """CSV representation of the tidy sample sales dataset."""
+
+    df = _sales_tidy_dataframe()
+    return df.to_csv(index=False).encode("utf-8-sig")
+
+
+def sample_sales_excel_bytes() -> bytes:
+    """Excel representation of the tidy sample sales dataset."""
+
+    buffer = io.BytesIO()
+    df = _sales_tidy_dataframe()
+    with pd.ExcelWriter(buffer, engine="openpyxl") as writer:
+        df.to_excel(writer, index=False, sheet_name="SampleSales")
+    buffer.seek(0)
+    return buffer.read()
+
+
+def _count_unique(values: Iterable[str]) -> int:
+    return len({value for value in values})
+
+
+def apply_sample_data_to_session() -> None:
+    """Populate Streamlit session state with the bundled sample dataset."""
+
+    bundle = create_sample_bundle()
+    st.session_state["finance_models"] = {
+        "sales": bundle.sales,
+        "costs": bundle.costs,
+        "capex": bundle.capex,
+        "loans": bundle.loans,
+        "tax": bundle.tax,
+    }
+    st.session_state["finance_raw"] = sample_finance_raw()
+    st.session_state["finance_validation_errors"] = []
+    template_df = _sales_template_dataframe()
+    st.session_state["sales_template_df"] = template_df
+    st.session_state["sales_channel_counter"] = _count_unique(
+        (spec.channel for spec in SAMPLE_SALES_SPECS)
+    ) + 1
+    st.session_state["sales_product_counter"] = _count_unique(
+        (spec.product for spec in SAMPLE_SALES_SPECS)
+    ) + 1
+    st.session_state["sample_data_loaded"] = True
+
+
+__all__ = [
+    "SAMPLE_FISCAL_YEAR",
+    "apply_sample_data_to_session",
+    "create_sample_bundle",
+    "sample_finance_raw",
+    "sample_sales_csv_bytes",
+    "sample_sales_excel_bytes",
+]
+

--- a/state.py
+++ b/state.py
@@ -59,6 +59,7 @@ STATE_SPECS: Dict[str, StateSpec] = {
     "what_if_default_customers": StateSpec(lambda: None, (float, int, type(None)), "顧客数の既定値"),
     "what_if_product_share": StateSpec(lambda: 0.6, (float, int), "製品売上比率の初期値"),
     "what_if_active": StateSpec(lambda: "A", str, "現在アクティブなWhat-ifシナリオ"),
+    "sample_data_loaded": StateSpec(lambda: False, bool, "サンプルデータ適用済みフラグ"),
     "finance_raw": StateSpec(dict, dict, "財務入力フォームの生データ"),
     "finance_models": StateSpec(dict, dict, "検証済みの財務モデル"),
     "finance_settings": StateSpec(

--- a/views/home.py
+++ b/views/home.py
@@ -9,6 +9,12 @@ import streamlit as st
 from calc import compute, plan_from_models, summarize_plan_metrics
 from formatting import format_amount_with_unit, format_ratio
 from state import ensure_session_defaults, load_finance_bundle, reset_app_state
+from sample_data import (
+    SAMPLE_FISCAL_YEAR,
+    apply_sample_data_to_session,
+    sample_sales_csv_bytes,
+    sample_sales_excel_bytes,
+)
 from theme import inject_theme
 from ui.chrome import HeaderActions, render_app_footer, render_app_header, render_usage_guide_panel
 
@@ -50,6 +56,7 @@ def render_home_page() -> None:
     fiscal_year = int(settings_state.get("fiscal_year", 2025))
 
     bundle, has_custom_inputs = load_finance_bundle()
+    sample_loaded = bool(st.session_state.get("sample_data_loaded", False))
 
     summary_tab, tutorial_tab = st.tabs(["概要", "チュートリアル"])
 
@@ -57,7 +64,44 @@ def render_home_page() -> None:
         st.subheader("📌 現状サマリー")
 
         if not has_custom_inputs:
-            st.info("入力ページでデータを保存すると、ここに最新のKPIが表示されます。")
+            st.info(
+                "まだ入力データがありません。サンプルを読み込むか、Inputsページで売上・コストなどを登録しましょう。"
+            )
+            prompt_cols = st.columns([1.6, 1, 1])
+            with prompt_cols[0]:
+                if st.button(
+                    "サンプルデータをロード",
+                    use_container_width=True,
+                    type="primary",
+                ):
+                    apply_sample_data_to_session()
+                    st.toast("サンプルデータを読み込みました。各ページが起動済みです。", icon="📦")
+                    st.experimental_rerun()
+            sample_csv = sample_sales_csv_bytes()
+            sample_excel = sample_sales_excel_bytes()
+            with prompt_cols[1]:
+                st.download_button(
+                    "CSVサンプルDL",
+                    data=sample_csv,
+                    file_name=f"sample_sales_{SAMPLE_FISCAL_YEAR}.csv",
+                    mime="text/csv",
+                    use_container_width=True,
+                    key="sample_csv_download_home",
+                )
+            with prompt_cols[2]:
+                st.download_button(
+                    "ExcelサンプルDL",
+                    data=sample_excel,
+                    file_name=f"sample_sales_{SAMPLE_FISCAL_YEAR}.xlsx",
+                    mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                    use_container_width=True,
+                    key="sample_excel_download_home",
+                )
+            st.caption(
+                "サンプルはカテゴリ・数量・月度（YYYY-MM）を含むデータセットです。オフラインで編集してテンプレートに貼り付けることもできます。"
+            )
+        elif sample_loaded:
+            st.success("サンプルデータを適用中です。Inputsページで自社データに置き換えて保存してください。")
 
         plan_cfg = plan_from_models(
             bundle.sales,


### PR DESCRIPTION
## Summary
- add a reusable sample_data module containing bundled sales/cost/capex/loan/tax fixtures plus CSV/XLSX export helpers
- show a first-run "Load sample data" CTA with download links and status messaging on the home dashboard
- surface the sample dataset download buttons and notices in the Inputs hub while tracking whether custom data has been saved

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68cec5051e948323ad43637522438654