### PR TITLE
Fix PDF line rendering with FPDF 2.7 API

### DIFF
--- a/pages/40_Report.py
+++ b/pages/40_Report.py
@@ -9,6 +9,7 @@ import pandas as pd
 import streamlit as st
 from docx import Document
 from fpdf import FPDF
+from fpdf.enums import XPos, YPos
 
 from calc import compute, plan_from_models, summarize_plan_metrics
 from formatting import UNIT_FACTORS, format_amount_with_unit, format_ratio, to_decimal
@@ -129,10 +130,16 @@ with pdf_tab:
     pdf = FPDF()
     pdf.add_page()
     pdf.set_font("Helvetica", size=14)
-    pdf.cell(0, 10, txt="Keiei Keikaku Studio | Summary Report", ln=True)
+    pdf.cell(
+        0,
+        10,
+        text="Keiei Keikaku Studio | Summary Report",
+        new_x=XPos.LMARGIN,
+        new_y=YPos.NEXT,
+    )
     pdf.set_font("Helvetica", size=11)
     for line in pdf_summary_lines:
-        pdf.multi_cell(0, 8, line)
+        pdf.multi_cell(0, 8, line, new_x=XPos.LMARGIN, new_y=YPos.NEXT)
     pdf.output(pdf_buffer)
     st.download_button(
         "📄 PDFダウンロード",


### PR DESCRIPTION
## Summary
- update the PDF export to use the modern FPDF XPos/YPos API so the cursor resets after each cell
- ensure each summary line renders by explicitly positioning the cursor for both the title cell and subsequent multi-cells

## Testing
- python -m compileall pages/40_Report.py

------
https://chatgpt.com/codex/tasks/task_e_68cf42a4dc04832384bdc1082e9acde3