### PR TITLE
Move sales template downloads outside form

### DIFF
--- a/pages/10_Inputs.py
+++ b/pages/10_Inputs.py
@@ -360,24 +360,25 @@ with sales_tab:
             month: st.column_config.NumberColumn(month, min_value=0.0, step=1.0, format="¥%d")
             for month in MONTH_COLUMNS
         }
+        download_cols = st.columns(2)
+        with download_cols[0]:
+            st.download_button(
+                "CSVテンプレートDL",
+                data=_sales_template_to_csv(sales_df),
+                file_name="sales_template.csv",
+                mime="text/csv",
+                use_container_width=True,
+            )
+        with download_cols[1]:
+            st.download_button(
+                "ExcelテンプレートDL",
+                data=_sales_template_to_excel(sales_df),
+                file_name="sales_template.xlsx",
+                mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                use_container_width=True,
+            )
+
         with st.form("sales_template_form"):
-            download_cols = st.columns(2)
-            with download_cols[0]:
-                st.download_button(
-                    "CSVテンプレートDL",
-                    data=_sales_template_to_csv(sales_df),
-                    file_name="sales_template.csv",
-                    mime="text/csv",
-                    use_container_width=True,
-                )
-            with download_cols[1]:
-                st.download_button(
-                    "ExcelテンプレートDL",
-                    data=_sales_template_to_excel(sales_df),
-                    file_name="sales_template.xlsx",
-                    mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-                    use_container_width=True,
-                )
             uploaded_template = st.file_uploader(
                 "テンプレートをアップロード (最大5MB)",
                 type=["csv", "xlsx"],


### PR DESCRIPTION
## Summary
- relocate the sales template download buttons out of the Streamlit form to avoid API exceptions during rendering

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68cf6a08c6e4832380fdb2d8cca2fe40