### PR TITLE
Fix Streamlit number format errors for yen inputs

### DIFF
--- a/pages/10_Inputs.py
+++ b/pages/10_Inputs.py
@@ -141,7 +141,15 @@ def _yen_number_input(
     step: float = 1.0,
     key: str | None = None,
 ) -> float:
-    kwargs = {"min_value": float(min_value), "step": float(step), "value": float(value), "format": "¥%.0f"}
+    # ``st.number_input`` in Streamlit 1.49+ rejects printf-style format strings
+    # that prefix currency symbols (e.g. ``¥``).  We therefore use a plain
+    # numeric format while keeping the unit in the label itself.
+    kwargs = {
+        "min_value": float(min_value),
+        "step": float(step),
+        "value": float(value),
+        "format": "%,.0f",
+    }
     if max_value is not None:
         kwargs["max_value"] = float(max_value)
     if key is not None:
@@ -357,7 +365,9 @@ with sales_tab:
 
         sales_df = st.session_state[SALES_TEMPLATE_STATE_KEY]
         month_columns_config = {
-            month: st.column_config.NumberColumn(month, min_value=0.0, step=1.0, format="¥%d")
+            month: st.column_config.NumberColumn(
+                month, min_value=0.0, step=1.0, format="%,.0f"
+            )
             for month in MONTH_COLUMNS
         }
         download_cols = st.columns(2)
@@ -510,7 +520,7 @@ with invest_tab:
         use_container_width=True,
         column_config={
             "金額": st.column_config.NumberColumn(
-                "金額 (円)", min_value=0.0, step=1_000_000.0, format="¥%d"
+                "金額 (円)", min_value=0.0, step=1_000_000.0, format="%,.0f"
             ),
             "開始月": st.column_config.NumberColumn("開始月", min_value=1, max_value=12, step=1),
             "耐用年数": st.column_config.NumberColumn("耐用年数 (年)", min_value=1, max_value=20, step=1),
@@ -525,7 +535,7 @@ with invest_tab:
         use_container_width=True,
         column_config={
             "元本": st.column_config.NumberColumn(
-                "元本 (円)", min_value=0.0, step=1_000_000.0, format="¥%d"
+                "元本 (円)", min_value=0.0, step=1_000_000.0, format="%,.0f"
             ),
             "金利": st.column_config.NumberColumn(
                 "金利 (小数)",


### PR DESCRIPTION
## Summary
- remove the yen symbol from number input format strings to satisfy Streamlit 1.49 validation
- keep the unit in labels and display comma-separated values in the sales, capex, and loan editors

## Testing
- python -m compileall pages/10_Inputs.py

------
https://chatgpt.com/codex/tasks/task_e_68cf6b47df748323bb34bea9db456db1