### PR TITLE
Apply unified branding and environment controls

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,7 +1,6 @@
 [theme]
-base = "system"
 primaryColor = "#1F4E79"
 backgroundColor = "#F7F9FB"
 secondaryBackgroundColor = "#FFFFFF"
 textColor = "#203040"
-font = "sans serif"
+font = "Noto Sans JP"

--- a/pages/00_Home.py
+++ b/pages/00_Home.py
@@ -3,12 +3,9 @@ from __future__ import annotations
 
 import streamlit as st
 
+from ui.chrome import apply_app_chrome
 from views import render_home_page
 
-st.set_page_config(
-    page_title="経営計画スタジオ｜概要",
-    page_icon="📊",
-    layout="wide",
-)
+apply_app_chrome()
 
 render_home_page()

--- a/pages/10_Inputs.py
+++ b/pages/10_Inputs.py
@@ -23,12 +23,9 @@ from sample_data import SAMPLE_FISCAL_YEAR, sample_sales_csv_bytes, sample_sales
 from state import ensure_session_defaults
 from theme import inject_theme
 from validators import ValidationIssue, validate_bundle
+from ui.chrome import apply_app_chrome
 
-st.set_page_config(
-    page_title="経営計画スタジオ｜Inputs",
-    page_icon="🧾",
-    layout="wide",
-)
+apply_app_chrome()
 
 inject_theme()
 ensure_session_defaults()

--- a/pages/20_Analysis.py
+++ b/pages/20_Analysis.py
@@ -21,6 +21,7 @@ from calc import (
 from formatting import format_amount_with_unit, format_ratio
 from state import ensure_session_defaults, load_finance_bundle
 from theme import inject_theme
+from ui.chrome import apply_app_chrome
 
 ITEM_LABELS = {code: label for code, label, _ in ITEMS}
 
@@ -188,11 +189,7 @@ def build_dscr_timeseries(statements: FinancialStatements) -> pd.DataFrame:
         )
     return pd.DataFrame(grouped_rows)
 
-st.set_page_config(
-    page_title="経営計画スタジオ｜Analysis",
-    page_icon="📈",
-    layout="wide",
-)
+apply_app_chrome()
 
 inject_theme()
 ensure_session_defaults()

--- a/pages/30_Scenarios.py
+++ b/pages/30_Scenarios.py
@@ -20,12 +20,9 @@ from formatting import format_amount_with_unit
 from models import CapexPlan, LoanSchedule, TaxPolicy
 from state import ensure_session_defaults, load_finance_bundle
 from theme import inject_theme
+from ui.chrome import apply_app_chrome
 
-st.set_page_config(
-    page_title="経営計画スタジオ｜Scenarios",
-    page_icon="🧮",
-    layout="wide",
-)
+apply_app_chrome()
 
 inject_theme()
 ensure_session_defaults()

--- a/pages/40_Report.py
+++ b/pages/40_Report.py
@@ -15,6 +15,7 @@ from calc import compute, plan_from_models, summarize_plan_metrics
 from formatting import UNIT_FACTORS, format_amount_with_unit, format_ratio, to_decimal
 from state import ensure_session_defaults, load_finance_bundle
 from theme import inject_theme
+from ui.chrome import apply_app_chrome
 
 
 PDF_UNIT_LABELS = {
@@ -75,11 +76,7 @@ def build_pdf_summary_lines(
         f"Break-even revenue: {format_amount_for_pdf(metrics.get('breakeven', Decimal('0')), unit)}",
     ]
 
-st.set_page_config(
-    page_title="経営計画スタジオ｜Report",
-    page_icon="📝",
-    layout="wide",
-)
+apply_app_chrome()
 
 inject_theme()
 ensure_session_defaults()

--- a/pages/90_Settings.py
+++ b/pages/90_Settings.py
@@ -14,12 +14,9 @@ from models import (
 )
 from state import ensure_session_defaults
 from theme import inject_theme
+from ui.chrome import apply_app_chrome
 
-st.set_page_config(
-    page_title="経営計画スタジオ｜Settings",
-    page_icon="⚙️",
-    layout="wide",
-)
+apply_app_chrome()
 
 inject_theme()
 ensure_session_defaults()

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,4 +1,4 @@
-"""Streamlit entry point – forwards to the shared home page renderer."""
+"""Streamlit Cloud entry point for the Keieiplan app."""
 from __future__ import annotations
 
 from ui.chrome import apply_app_chrome

--- a/ui/chrome.py
+++ b/ui/chrome.py
@@ -1,16 +1,157 @@
-"""Shared UI chrome elements (header, footer, help tools)."""
 from __future__ import annotations
 
+from base64 import b64decode
 from dataclasses import dataclass
-from typing import Callable
+from pathlib import Path
+from typing import Callable, Dict
 
 import streamlit as st
+
+APP_PAGE_TITLE = "経営計画スタジオ"
+APP_PAGE_ICON = "📊"
+APP_PAGE_CONFIG = {
+    "page_title": APP_PAGE_TITLE,
+    "page_icon": APP_PAGE_ICON,
+    "layout": "wide",
+}
+
+LOGO_LIGHT_PATH = Path("assets/logo.png")
+LOGO_DARK_PATH = Path("assets/logo_dark.png")
+LOGO_ALT_TEXT = "経営計画スタジオのロゴ"
+PLACEHOLDER_LOGO_BYTES = b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAMAAWgmWQ0AAAAASUVORK5CYII="
+)
+
+ENVIRONMENT_SETTINGS_KEY = "environment_settings"
+ENVIRONMENT_DEFAULTS: Dict[str, float | int | str] = {
+    "currency": "JPY (¥)",
+    "consumption_tax_rate": 0.1,
+    "fiscal_year": 2025,
+    "decimal_places": 0,
+}
+
+ENVIRONMENT_WIDGET_KEYS = {
+    "currency": "environment_currency",
+    "consumption_tax_rate": "environment_consumption_tax_percent",
+    "fiscal_year": "environment_fiscal_year",
+    "decimal_places": "environment_decimal_places",
+}
+
+CURRENCY_OPTIONS = [
+    "JPY (¥)",
+    "USD ($)",
+    "EUR (€)",
+    "GBP (£)",
+]
+
+DECIMAL_PLACE_OPTIONS = [0, 1, 2, 3]
 
 USAGE_GUIDE_TEXT = (
     "1. **入力を整える**: コントロールハブで売上・コストのレバーと会計年度、FTEを設定します。\n"
     "2. **検証と分析**: シナリオ/感応度タブで前提を比較し、AIインサイトでチェックポイントを確認します。\n"
     "3. **可視化と出力**: グラフや表で可視化し、エクスポートタブからExcelをダウンロードして共有します。"
 )
+
+
+def apply_app_chrome() -> None:
+    """Configure the Streamlit page and global chrome elements."""
+
+    st.set_page_config(**APP_PAGE_CONFIG)
+    _render_logo()
+    _render_environment_sidebar()
+
+
+def _render_logo() -> None:
+    """Display the application logo with graceful fallbacks."""
+
+    logo_source: str | Dict[str, str]
+    try:
+        if not LOGO_LIGHT_PATH.exists():
+            raise FileNotFoundError(LOGO_LIGHT_PATH)
+        if LOGO_DARK_PATH.exists():
+            logo_source = {
+                "light": str(LOGO_LIGHT_PATH),
+                "dark": str(LOGO_DARK_PATH),
+            }
+        else:
+            logo_source = str(LOGO_LIGHT_PATH)
+        st.logo(logo_source, icon_image=str(LOGO_LIGHT_PATH), alt=LOGO_ALT_TEXT)
+    except FileNotFoundError:
+        st.logo(PLACEHOLDER_LOGO_BYTES, alt=LOGO_ALT_TEXT)
+        st.sidebar.info("assets/logo.png を配置するとブランドロゴが表示されます。")
+    except Exception as exc:  # pragma: no cover - defensive UI feedback
+        st.logo(PLACEHOLDER_LOGO_BYTES, alt=LOGO_ALT_TEXT)
+        st.sidebar.warning(f"ロゴを読み込めませんでした: {exc}")
+
+
+def _render_environment_sidebar() -> None:
+    """Render shared environment preferences in the sidebar."""
+
+    defaults = _ensure_environment_defaults()
+
+    st.session_state.setdefault(
+        ENVIRONMENT_WIDGET_KEYS["currency"], defaults["currency"]
+    )
+    st.session_state.setdefault(
+        ENVIRONMENT_WIDGET_KEYS["consumption_tax_rate"],
+        defaults["consumption_tax_rate"] * 100,
+    )
+    st.session_state.setdefault(
+        ENVIRONMENT_WIDGET_KEYS["fiscal_year"], defaults["fiscal_year"]
+    )
+    st.session_state.setdefault(
+        ENVIRONMENT_WIDGET_KEYS["decimal_places"], defaults["decimal_places"]
+    )
+
+    with st.sidebar:
+        st.markdown("### ⚙️ 環境設定")
+        selected_currency = st.selectbox(
+            "通貨",
+            options=CURRENCY_OPTIONS,
+            key=ENVIRONMENT_WIDGET_KEYS["currency"],
+        )
+        consumption_tax_percent = st.number_input(
+            "消費税率 (%)",
+            min_value=0.0,
+            max_value=25.0,
+            step=0.1,
+            format="%.1f",
+            key=ENVIRONMENT_WIDGET_KEYS["consumption_tax_rate"],
+        )
+        fiscal_year = st.number_input(
+            "会計年度",
+            min_value=2000,
+            max_value=2100,
+            step=1,
+            key=ENVIRONMENT_WIDGET_KEYS["fiscal_year"],
+        )
+        decimal_places = st.selectbox(
+            "小数点桁",
+            options=DECIMAL_PLACE_OPTIONS,
+            key=ENVIRONMENT_WIDGET_KEYS["decimal_places"],
+            format_func=lambda value: f"{value}桁",
+        )
+        st.caption("設定はセッション内で保持され、全ページで共有されます。")
+
+    st.session_state[ENVIRONMENT_SETTINGS_KEY] = {
+        "currency": selected_currency,
+        "consumption_tax_rate": round(consumption_tax_percent / 100, 4),
+        "fiscal_year": int(fiscal_year),
+        "decimal_places": int(decimal_places),
+    }
+
+
+def _ensure_environment_defaults() -> Dict[str, float | int | str]:
+    """Ensure default environment settings exist in the session."""
+
+    stored = st.session_state.get(ENVIRONMENT_SETTINGS_KEY)
+    defaults = ENVIRONMENT_DEFAULTS.copy()
+    if isinstance(stored, dict):
+        for key, value in stored.items():
+            if key in defaults:
+                defaults[key] = value
+    st.session_state[ENVIRONMENT_SETTINGS_KEY] = defaults
+    return defaults
 
 
 @dataclass(frozen=True)
@@ -84,6 +225,7 @@ def render_app_footer(
 
 
 __all__ = [
+    "apply_app_chrome",
     "HeaderActions",
     "render_app_footer",
     "render_app_header",


### PR DESCRIPTION
## Summary
- add a dedicated `apply_app_chrome` helper that standardises page config, renders the brand logo with fallbacks, and surfaces shared environment settings in the sidebar
- configure Streamlit's theme (primary/background/text colours and Japanese font) via `.streamlit/config.toml`
- update every entry point to rely on the shared chrome helper and add a `streamlit_app.py` entry for Streamlit Cloud deployments

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68cf707c723c8323a1c7e9239f1e5fe5