### PR TITLE
Add flexible finance settings and forecast controls

### DIFF
--- a/state.py
+++ b/state.py
@@ -64,7 +64,15 @@ STATE_SPECS: Dict[str, StateSpec] = {
     "finance_raw": StateSpec(dict, dict, "財務入力フォームの生データ"),
     "finance_models": StateSpec(dict, dict, "検証済みの財務モデル"),
     "finance_settings": StateSpec(
-        lambda: {"unit": "百万円", "language": "ja", "fte": 20.0, "fiscal_year": 2025},
+        lambda: {
+            "unit": "百万円",
+            "language": "ja",
+            "currency": "JPY",
+            "fte": 20.0,
+            "fiscal_year": 2025,
+            "fiscal_year_start_month": 4,
+            "forecast_years": 3,
+        },
         dict,
         "共通設定（単位・言語・FTEなど）",
     ),


### PR DESCRIPTION
## Summary
- add a finance control hub that lets users choose display units, currency, fiscal year start month, forecast horizon, and includes FTE guidance with a calculator-driven workflow
- expand currency and unit formatting utilities and propagate the chosen settings through PlanConfig so downstream computations respect the selected start month and horizon
- surface new forecast tables and monthly highlights in the home summary to reflect the chosen configuration

## Testing
- python -m compileall formatting.py calc/pl.py calc/statements.py state.py views/home.py

------
https://chatgpt.com/codex/tasks/task_e_68cf885bac308323804030ce60c71ba3