### PR TITLE
Add strategy framework settings and dashboard integration

### DIFF
--- a/app.py
+++ b/app.py
@@ -30,6 +30,11 @@ def _build_navigation(language: str) -> list[st.Page]:
             icon=":pencil2:",
         ),
         st.Page(
+            "pages/7_戦略フレームワーク設定.py",
+            title=t("navigation.strategy"),
+            icon=":dart:",
+        ),
+        st.Page(
             "pages/3_シナリオ&感度分析.py",
             title=t("navigation.scenario"),
             icon=":game_die:",

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
-from . import charts, exporters, finance, io, validators
+from . import charts, exporters, finance, io, strategy, validators
 
 __all__ = [
     "charts",
     "exporters",
     "finance",
     "io",
+    "strategy",
     "validators",
 ]

--- a/core/io.py
+++ b/core/io.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, Mapping
 
 import pandas as pd
 
+from . import strategy as strategy_utils
 from models import (
     CapexPlan,
     CostPlan,
@@ -175,6 +176,7 @@ def prepare_finance_export_payload(
     working_capital: WorkingCapitalAssumptions,
     settings: Mapping[str, Any],
     metadata: Mapping[str, Any] | None = None,
+    strategy: Mapping[str, Any] | None = None,
 ) -> Dict[str, pd.DataFrame]:
     """Build a mapping of sheet name to DataFrame for export."""
 
@@ -209,6 +211,10 @@ def prepare_finance_export_payload(
         "tax": _tax_to_dataframe(tax),
         "working_capital": _working_capital_to_dataframe(working_capital),
     }
+    strategy_state = strategy or {}
+    payload["strategy_bsc"] = strategy_utils.bsc_to_dataframe(strategy_state.get("bsc", {}))
+    payload["strategy_pest"] = strategy_utils.pest_to_dataframe(strategy_state.get("pest", {}))
+    payload["strategy_swot"] = strategy_utils.swot_to_dataframe(strategy_state.get("swot", {}))
     return payload
 
 
@@ -454,6 +460,7 @@ def import_finance_payload(file: UploadedFile | None) -> tuple[dict[str, Any], l
         "tax": tax,
         "working_capital": working_capital,
     }
+    result["strategy"] = strategy_utils.frames_to_strategy(frames)
 
     return result, warnings
 

--- a/core/strategy.py
+++ b/core/strategy.py
@@ -1,0 +1,445 @@
+"""Utilities for managing strategy frameworks such as BSC, PEST and SWOT."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any, Dict, Iterable, List, Mapping, Sequence, Tuple
+
+import pandas as pd
+
+from formatting import format_amount_with_unit, format_ratio, to_decimal
+from models import FinanceBundle
+
+BSC_PERSPECTIVES: List[Tuple[str, str]] = [
+    ("financial", "財務"),
+    ("customer", "顧客"),
+    ("process", "内部プロセス"),
+    ("learning", "学習・成長"),
+]
+
+PEST_DIMENSIONS: List[Tuple[str, str, str]] = [
+    ("political", "政治", "規制・税制、政策動向"),
+    ("economic", "経済", "成長率・物価、為替"),
+    ("social", "社会", "人口動態・価値観"),
+    ("technological", "技術", "自動化・技術変化"),
+]
+
+SWOT_CATEGORIES: List[Tuple[str, str]] = [
+    ("strengths", "強み"),
+    ("weaknesses", "弱み"),
+    ("opportunities", "機会"),
+    ("threats", "脅威"),
+]
+
+
+def default_bsc_state() -> Dict[str, List[Dict[str, str]]]:
+    """Return an empty structure for BSC perspective entries."""
+
+    return {key: [] for key, _ in BSC_PERSPECTIVES}
+
+
+def default_pest_state() -> Dict[str, List[str]]:
+    """Return an empty structure for PEST entries."""
+
+    return {key: [] for key, *_ in PEST_DIMENSIONS}
+
+
+def default_swot_state() -> Dict[str, List[str]]:
+    """Return an empty structure for SWOT entries."""
+
+    return {key: [] for key, _ in SWOT_CATEGORIES}
+
+
+def _ensure_iterable(value: Any) -> Iterable[Any]:
+    if value is None or isinstance(value, (str, bytes)):
+        return []
+    if isinstance(value, Mapping):
+        return value.values()
+    if isinstance(value, Iterable):
+        return value
+    return []
+
+
+def normalize_bsc_state(data: Mapping[str, Any] | None) -> Dict[str, List[Dict[str, str]]]:
+    """Return a sanitized BSC dictionary suitable for storage and rendering."""
+
+    normalized = default_bsc_state()
+    if not isinstance(data, Mapping):
+        return normalized
+    for key in normalized:
+        entries = []
+        raw_entries = data.get(key)
+        for item in _ensure_iterable(raw_entries):
+            if isinstance(item, Mapping):
+                objective = str(item.get("objective", "")).strip()
+                metric = str(item.get("metric", "")).strip()
+                target = str(item.get("target", "")).strip()
+            elif isinstance(item, Sequence) and not isinstance(item, (str, bytes)):
+                parts = list(item) + ["", "", ""]
+                objective = str(parts[0]).strip()
+                metric = str(parts[1]).strip()
+                target = str(parts[2]).strip()
+            else:
+                continue
+            if not any([objective, metric, target]):
+                continue
+            entries.append({
+                "objective": objective,
+                "metric": metric,
+                "target": target,
+            })
+        normalized[key] = entries
+    return normalized
+
+
+def normalize_pest_state(data: Mapping[str, Any] | None) -> Dict[str, List[str]]:
+    """Return a sanitized PEST dictionary."""
+
+    normalized = default_pest_state()
+    if not isinstance(data, Mapping):
+        return normalized
+    for key in normalized:
+        entries: List[str] = []
+        raw_entries = data.get(key)
+        for item in _ensure_iterable(raw_entries):
+            text = str(item).strip()
+            if text:
+                entries.append(text)
+        normalized[key] = entries
+    return normalized
+
+
+def normalize_swot_state(data: Mapping[str, Any] | None) -> Dict[str, List[str]]:
+    """Return a sanitized SWOT dictionary."""
+
+    normalized = default_swot_state()
+    if not isinstance(data, Mapping):
+        return normalized
+    for key in normalized:
+        entries: List[str] = []
+        raw_entries = data.get(key)
+        for item in _ensure_iterable(raw_entries):
+            text = str(item).strip()
+            if text:
+                entries.append(text)
+        normalized[key] = entries
+    return normalized
+
+
+def bsc_to_dataframe(state: Mapping[str, Any]) -> pd.DataFrame:
+    """Convert BSC entries into a normalized DataFrame for export."""
+
+    normalized = normalize_bsc_state(state)
+    rows: List[Dict[str, str]] = []
+    for key, _label in BSC_PERSPECTIVES:
+        for entry in normalized.get(key, []):
+            rows.append(
+                {
+                    "perspective": key,
+                    "objective": entry.get("objective", ""),
+                    "metric": entry.get("metric", ""),
+                    "target": entry.get("target", ""),
+                }
+            )
+    frame = pd.DataFrame(rows)
+    if frame.empty:
+        frame = pd.DataFrame(columns=["perspective", "objective", "metric", "target"])
+    return frame
+
+
+def pest_to_dataframe(state: Mapping[str, Any]) -> pd.DataFrame:
+    """Convert PEST entries into a DataFrame for export."""
+
+    normalized = normalize_pest_state(state)
+    rows: List[Dict[str, str]] = []
+    for key, _label, _ in PEST_DIMENSIONS:
+        for entry in normalized.get(key, []):
+            rows.append({"dimension": key, "factor": entry})
+    frame = pd.DataFrame(rows)
+    if frame.empty:
+        frame = pd.DataFrame(columns=["dimension", "factor"])
+    return frame
+
+
+def swot_to_dataframe(state: Mapping[str, Any]) -> pd.DataFrame:
+    """Convert SWOT entries into a DataFrame for export."""
+
+    normalized = normalize_swot_state(state)
+    rows: List[Dict[str, str]] = []
+    for key, _label in SWOT_CATEGORIES:
+        for entry in normalized.get(key, []):
+            rows.append({"category": key, "item": entry})
+    frame = pd.DataFrame(rows)
+    if frame.empty:
+        frame = pd.DataFrame(columns=["category", "item"])
+    return frame
+
+
+def dataframe_to_bsc(frame: pd.DataFrame | None) -> Dict[str, List[Dict[str, str]]]:
+    """Convert an exported BSC frame back into the session structure."""
+
+    if frame is None or frame.empty:
+        return default_bsc_state()
+    perspective_col = _resolve_column(frame, {"perspective"})
+    objective_col = _resolve_column(frame, {"objective"})
+    metric_col = _resolve_column(frame, {"metric"})
+    target_col = _resolve_column(frame, {"target"})
+    if not all([perspective_col, objective_col, metric_col, target_col]):
+        return default_bsc_state()
+    grouped: Dict[str, List[Dict[str, str]]] = default_bsc_state()
+    records = frame.where(pd.notna(frame), "").to_dict(orient="records")
+    for row in records:
+        perspective = str(row.get(perspective_col, "")).strip()
+        objective = str(row.get(objective_col, "")).strip()
+        metric = str(row.get(metric_col, "")).strip()
+        target = str(row.get(target_col, "")).strip()
+        if perspective not in grouped:
+            continue
+        if not any([objective, metric, target]):
+            continue
+        grouped[perspective].append(
+            {"objective": objective, "metric": metric, "target": target}
+        )
+    return grouped
+
+
+def dataframe_to_pest(frame: pd.DataFrame | None) -> Dict[str, List[str]]:
+    """Convert an exported PEST frame back into the session structure."""
+
+    if frame is None or frame.empty:
+        return default_pest_state()
+    dimension_col = _resolve_column(frame, {"dimension"})
+    factor_col = _resolve_column(frame, {"factor"})
+    if not all([dimension_col, factor_col]):
+        return default_pest_state()
+    grouped: Dict[str, List[str]] = default_pest_state()
+    records = frame.where(pd.notna(frame), "").to_dict(orient="records")
+    for row in records:
+        dimension = str(row.get(dimension_col, "")).strip()
+        if dimension not in grouped:
+            continue
+        factor = str(row.get(factor_col, "")).strip()
+        if factor:
+            grouped[dimension].append(factor)
+    return grouped
+
+
+def dataframe_to_swot(frame: pd.DataFrame | None) -> Dict[str, List[str]]:
+    """Convert an exported SWOT frame back into the session structure."""
+
+    if frame is None or frame.empty:
+        return default_swot_state()
+    category_col = _resolve_column(frame, {"category"})
+    item_col = _resolve_column(frame, {"item"})
+    if not all([category_col, item_col]):
+        return default_swot_state()
+    grouped: Dict[str, List[str]] = default_swot_state()
+    records = frame.where(pd.notna(frame), "").to_dict(orient="records")
+    for row in records:
+        category = str(row.get(category_col, "")).strip()
+        if category not in grouped:
+            continue
+        item = str(row.get(item_col, "")).strip()
+        if item:
+            grouped[category].append(item)
+    return grouped
+
+
+def _resolve_column(frame: pd.DataFrame, candidates: Iterable[str]) -> str | None:
+    available = {str(col).lower(): str(col) for col in frame.columns}
+    for candidate in candidates:
+        key = str(candidate).lower()
+        if key in available:
+            return available[key]
+    return None
+
+
+def build_bsc_display_frame(state: Mapping[str, Any]) -> pd.DataFrame:
+    """Return a DataFrame optimised for on-screen display of BSC entries."""
+
+    frame = bsc_to_dataframe(state)
+    if frame.empty:
+        return pd.DataFrame(columns=["視点", "目標", "指標", "ターゲット"])
+    label_map = {key: label for key, label in BSC_PERSPECTIVES}
+    frame = frame.assign(視点=frame["perspective"].map(label_map).fillna(frame["perspective"]))
+    frame = frame.rename(columns={"objective": "目標", "metric": "指標", "target": "ターゲット"})
+    return frame[["視点", "目標", "指標", "ターゲット"]]
+
+
+def build_pest_display(state: Mapping[str, Any]) -> Dict[str, List[str]]:
+    """Return PEST entries keyed by dimension label for display."""
+
+    normalized = normalize_pest_state(state)
+    label_map = {key: label for key, label, _ in PEST_DIMENSIONS}
+    return {label_map[key]: normalized.get(key, []) for key in normalized}
+
+
+def build_swot_display(state: Mapping[str, Any]) -> Dict[str, List[str]]:
+    """Return SWOT entries keyed by category label for display."""
+
+    normalized = normalize_swot_state(state)
+    label_map = {key: label for key, label in SWOT_CATEGORIES}
+    return {label_map[key]: normalized.get(key, []) for key in normalized}
+
+
+def summarize_financial_context(bundle: FinanceBundle) -> Dict[str, Decimal]:
+    """Extract lightweight financial indicators for strategic insights."""
+
+    annual_sales = bundle.sales.annual_total()
+    variable_ratio = sum(bundle.costs.variable_ratios.values(), start=Decimal("0"))
+    if variable_ratio < Decimal("0"):
+        variable_ratio = Decimal("0")
+    if variable_ratio > Decimal("1"):
+        variable_ratio = Decimal("1")
+    gross_margin_ratio = Decimal("1") - variable_ratio
+    fixed_cost_total = sum(bundle.costs.fixed_costs.values(), start=Decimal("0"))
+    fixed_cost_ratio = Decimal("0")
+    if annual_sales and annual_sales != Decimal("0"):
+        fixed_cost_ratio = (fixed_cost_total / annual_sales).quantize(Decimal("0.0001"))
+    non_operating_income = sum(bundle.costs.non_operating_income.values(), start=Decimal("0"))
+    non_operating_expenses = sum(bundle.costs.non_operating_expenses.values(), start=Decimal("0"))
+    non_operating_balance = non_operating_income - non_operating_expenses
+    return {
+        "annual_sales": annual_sales,
+        "gross_margin_ratio": gross_margin_ratio,
+        "fixed_cost_total": fixed_cost_total,
+        "fixed_cost_ratio": fixed_cost_ratio,
+        "non_operating_balance": non_operating_balance,
+    }
+
+
+def generate_swot_suggestions(
+    swot_state: Mapping[str, Any],
+    pest_state: Mapping[str, Any],
+    finance_summary: Mapping[str, Any],
+    *,
+    unit: str,
+    currency: str,
+    bsc_state: Mapping[str, Any] | None = None,
+) -> List[str]:
+    """Generate qualitative suggestions referencing SWOT/PEST/finance inputs."""
+
+    normalized_swot = normalize_swot_state(swot_state)
+    normalized_pest = normalize_pest_state(pest_state)
+    normalized_bsc = normalize_bsc_state(bsc_state or {})
+
+    suggestions: List[str] = []
+
+    annual_sales = to_decimal(finance_summary.get("annual_sales", Decimal("0")))
+    if annual_sales > 0:
+        suggestions.append(
+            "年間売上規模は"
+            f"{format_amount_with_unit(annual_sales, unit, currency=currency)}です。"
+            " 強みセクションでは市場シェアや価格交渉力の裏付けとして活用しましょう。"
+        )
+
+    gross_margin_ratio = to_decimal(finance_summary.get("gross_margin_ratio", Decimal("0")))
+    if gross_margin_ratio > Decimal("0"):
+        if gross_margin_ratio >= Decimal("0.40"):
+            suggestions.append(
+                f"粗利率は{format_ratio(gross_margin_ratio)}で推移しています。"
+                " 高付加価値サービスやプレミアム価格戦略を強み・機会に紐づけると説得力が高まります。"
+            )
+        else:
+            suggestions.append(
+                f"粗利率が{format_ratio(gross_margin_ratio)}に留まっています。"
+                " 弱みでは原価改善や値上げ交渉のアクションを検討しましょう。"
+            )
+
+    fixed_cost_ratio = to_decimal(finance_summary.get("fixed_cost_ratio", Decimal("0")))
+    if fixed_cost_ratio > Decimal("0"):
+        if fixed_cost_ratio >= Decimal("0.35"):
+            suggestions.append(
+                f"固定費比率が{format_ratio(fixed_cost_ratio)}まで上昇しています。"
+                " 脅威・弱みでは固定費最適化や業務再設計の必要性を明記するのが有効です。"
+            )
+        elif fixed_cost_ratio >= Decimal("0.20"):
+            suggestions.append(
+                f"固定費比率は{format_ratio(fixed_cost_ratio)}です。"
+                " BSCの内部プロセス視点と連動し、生産性向上のKPIを設定しましょう。"
+            )
+
+    technological = normalized_pest.get("technological", [])
+    if technological:
+        highlight = technological[0]
+        suggestions.append(
+            f"技術トレンドとして『{highlight}』が挙がっています。"
+            " 機会にはデジタル投資や自動化による競争優位の創出を盛り込みましょう。"
+        )
+
+    political = normalized_pest.get("political", [])
+    if political:
+        suggestions.append(
+            "政治・規制の変化が複数登録されています。脅威セクションで規制対応ロードマップを整理するとリスク対策が明確になります。"
+        )
+
+    economic = normalized_pest.get("economic", [])
+    if economic:
+        suggestions.append(
+            "経済環境の前提は需要予測や価格設定に直結します。財務視点のKPIと連携し、シナリオ分析とセットで説明すると良いでしょう。"
+        )
+
+    learning_entries = normalized_bsc.get("learning", [])
+    if learning_entries:
+        suggestions.append(
+            "学習・成長視点で人材育成テーマが設定されています。強みや機会の実行計画に育成ロードマップを紐づけると整合性が高まります。"
+        )
+
+    if not suggestions and any(normalized_swot.values()):
+        suggestions.append(
+            "SWOT入力が保存されています。PESTや財務指標と突き合わせて、各象限のアクションプランを明文化しましょう。"
+        )
+
+    return suggestions
+
+
+def frames_to_strategy(frames: Mapping[str, pd.DataFrame]) -> Dict[str, Any]:
+    """Convert exported frames into the strategy state structure."""
+
+    bsc = dataframe_to_bsc(frames.get("strategy_bsc"))
+    pest = dataframe_to_pest(frames.get("strategy_pest"))
+    swot = dataframe_to_swot(frames.get("strategy_swot"))
+    return {"bsc": bsc, "pest": pest, "swot": swot}
+
+
+def has_bsc_entries(state: Mapping[str, Any]) -> bool:
+    normalized = normalize_bsc_state(state)
+    return any(normalized[key] for key in normalized)
+
+
+def has_pest_entries(state: Mapping[str, Any]) -> bool:
+    normalized = normalize_pest_state(state)
+    return any(normalized[key] for key in normalized)
+
+
+def has_swot_entries(state: Mapping[str, Any]) -> bool:
+    normalized = normalize_swot_state(state)
+    return any(normalized[key] for key in normalized)
+
+
+__all__ = [
+    "BSC_PERSPECTIVES",
+    "PEST_DIMENSIONS",
+    "SWOT_CATEGORIES",
+    "default_bsc_state",
+    "default_pest_state",
+    "default_swot_state",
+    "normalize_bsc_state",
+    "normalize_pest_state",
+    "normalize_swot_state",
+    "bsc_to_dataframe",
+    "pest_to_dataframe",
+    "swot_to_dataframe",
+    "dataframe_to_bsc",
+    "dataframe_to_pest",
+    "dataframe_to_swot",
+    "build_bsc_display_frame",
+    "build_pest_display",
+    "build_swot_display",
+    "summarize_financial_context",
+    "generate_swot_suggestions",
+    "frames_to_strategy",
+    "has_bsc_entries",
+    "has_pest_entries",
+    "has_swot_entries",
+]

--- a/localization/locales/en.json
+++ b/localization/locales/en.json
@@ -8,6 +8,7 @@
     "localization": "Language & Localization",
     "dashboard": "Dashboard",
     "data_entry": "Data Entry",
+    "strategy": "Strategy",
     "scenario": "Scenarios & Sensitivity",
     "segment": "Segment Performance",
     "funding": "Funding & Banking Docs",
@@ -118,6 +119,10 @@
       "caption": "Get a high-level overview of core performance metrics.",
       "todo_header": "TODO",
       "todo_description": "Add KPI cards and visualizations for the primary metrics."
+    },
+    "strategy": {
+      "title": "Strategy framework settings",
+      "caption": "Capture BSC, PEST and SWOT inputs and make them available on dashboards and reports."
     },
     "data_entry": {
       "title": "Data Entry",

--- a/localization/locales/ja.json
+++ b/localization/locales/ja.json
@@ -8,6 +8,7 @@
     "localization": "言語とローカライズ",
     "dashboard": "ダッシュボード",
     "data_entry": "データ入力",
+    "strategy": "戦略設定",
     "scenario": "シナリオ & 感度分析",
     "segment": "店舗 / 部門 / チャネル分析",
     "funding": "補助金 / 金融機関資料",
@@ -118,6 +119,10 @@
       "caption": "経営指標の俯瞰ビューを提供します。",
       "todo_header": "TODO",
       "todo_description": "主要なチャートやKPIカードを追加してください。"
+    },
+    "strategy": {
+      "title": "戦略フレームワーク設定",
+      "caption": "BSC・PEST・SWOTを入力し、戦略指標をダッシュボードとレポートに連携します。"
     },
     "data_entry": {
       "title": "データ入力",

--- a/localization/locales/ko.json
+++ b/localization/locales/ko.json
@@ -8,6 +8,7 @@
     "localization": "언어 및 현지화",
     "dashboard": "대시보드",
     "data_entry": "데이터 입력",
+    "strategy": "전략 설정",
     "scenario": "시나리오·민감도 분석",
     "segment": "매장 / 부문 / 채널 분석",
     "funding": "보조금·금융 자료",
@@ -118,6 +119,10 @@
       "caption": "핵심 경영 지표를 한눈에 확인합니다.",
       "todo_header": "TODO",
       "todo_description": "주요 KPI 카드와 시각화를 추가해 주세요."
+    },
+    "strategy": {
+      "title": "전략 프레임워크 설정",
+      "caption": "BSC·PEST·SWOT 입력을 통합하여 대시보드와 보고서에 연동합니다."
     },
     "data_entry": {
       "title": "데이터 입력",

--- a/localization/locales/zh-Hans.json
+++ b/localization/locales/zh-Hans.json
@@ -8,6 +8,7 @@
     "localization": "语言与本地化",
     "dashboard": "仪表板",
     "data_entry": "数据录入",
+    "strategy": "战略设置",
     "scenario": "情景与敏感度分析",
     "segment": "门店 / 部门 / 渠道分析",
     "funding": "补贴与金融资料",
@@ -118,6 +119,10 @@
       "caption": "总览核心经营指标。",
       "todo_header": "待办",
       "todo_description": "请添加主要KPI的图表与卡片。"
+    },
+    "strategy": {
+      "title": "战略框架设置",
+      "caption": "录入BSC、PEST与SWOT并同步到仪表板与报告。"
     },
     "data_entry": {
       "title": "数据录入",

--- a/pages/1_ダッシュボード.py
+++ b/pages/1_ダッシュボード.py
@@ -2,8 +2,84 @@ from __future__ import annotations
 
 import streamlit as st
 
-from core import charts, finance
+from core import charts, finance, strategy
 from localization import render_language_status_alert, translate
+from state import load_finance_bundle
+
+
+def _render_strategy_overview() -> None:
+    st.markdown("### 戦略フレームワークハイライト")
+
+    bsc_state = st.session_state.get("strategy_bsc", {})
+    pest_state = st.session_state.get("strategy_pest", {})
+    swot_state = st.session_state.get("strategy_swot", {})
+
+    has_any = (
+        strategy.has_bsc_entries(bsc_state)
+        or strategy.has_pest_entries(pest_state)
+        or strategy.has_swot_entries(swot_state)
+    )
+
+    if not has_any:
+        st.info("設定ページのBSC・PEST・SWOTに入力するとここに要約が表示されます。")
+        return
+
+    if strategy.has_bsc_entries(bsc_state):
+        st.markdown("#### バランス・スコアカード")
+        bsc_frame = strategy.build_bsc_display_frame(bsc_state)
+        st.dataframe(bsc_frame, use_container_width=True, hide_index=True)
+    else:
+        st.caption("BSCは未登録です。")
+
+    if strategy.has_pest_entries(pest_state):
+        st.markdown("#### PESTサマリー")
+        pest_map = strategy.build_pest_display(pest_state)
+        pest_cols = st.columns(2)
+        for index, (label, entries) in enumerate(pest_map.items()):
+            column = pest_cols[index % 2]
+            with column:
+                st.markdown(f"**{label}**")
+                if entries:
+                    for entry in entries:
+                        st.markdown(f"- {entry}")
+                else:
+                    st.caption("未入力です。")
+    else:
+        st.caption("PESTは未登録です。")
+
+    if strategy.has_swot_entries(swot_state):
+        st.markdown("#### SWOTサマリー")
+        swot_map = strategy.build_swot_display(swot_state)
+        swot_cols = st.columns(2)
+        for index, (label, entries) in enumerate(swot_map.items()):
+            column = swot_cols[index % 2]
+            with column:
+                st.markdown(f"**{label}**")
+                if entries:
+                    for entry in entries:
+                        st.markdown(f"- {entry}")
+                else:
+                    st.caption("未入力です。")
+
+        settings = st.session_state.get("finance_settings", {})
+        unit = str(settings.get("unit", "百万円"))
+        currency = str(settings.get("currency", "JPY"))
+        bundle, _ = load_finance_bundle()
+        finance_summary = strategy.summarize_financial_context(bundle)
+        suggestions = strategy.generate_swot_suggestions(
+            swot_state,
+            pest_state,
+            finance_summary,
+            unit=unit,
+            currency=currency,
+            bsc_state=bsc_state,
+        )
+        if suggestions:
+            st.markdown("**AIサポートコメント**")
+            for suggestion in suggestions:
+                st.markdown(f"- {suggestion}")
+    else:
+        st.caption("SWOTは未登録です。")
 
 
 def main() -> None:
@@ -13,6 +89,8 @@ def main() -> None:
 
     metrics = finance.calculate_key_metrics()
     charts.display_metric_overview(metrics)
+
+    _render_strategy_overview()
 
     st.markdown(f"### {translate('pages.dashboard.todo_header')}")
     st.info(translate("pages.dashboard.todo_description"))

--- a/pages/2_データ入力.py
+++ b/pages/2_データ入力.py
@@ -7,7 +7,7 @@ from typing import Any, Dict
 import pandas as pd
 import streamlit as st
 
-from core import io
+from core import io, strategy
 from core.templates import list_industry_templates
 from formatting import format_amount_with_unit
 from localization import render_language_status_alert, translate, translate_list
@@ -207,6 +207,11 @@ def _render_export_import_panel() -> None:
     bundle, _ = load_finance_bundle()
     settings_state: Dict[str, Any] = st.session_state.get("finance_settings", {})
     metadata = st.session_state.get("industry_template_state", {})
+    strategy_payload = {
+        "bsc": st.session_state.get("strategy_bsc", {}),
+        "pest": st.session_state.get("strategy_pest", {}),
+        "swot": st.session_state.get("strategy_swot", {}),
+    }
     payload = io.prepare_finance_export_payload(
         sales=bundle.sales,
         costs=bundle.costs,
@@ -216,6 +221,7 @@ def _render_export_import_panel() -> None:
         working_capital=bundle.working_capital,
         settings=settings_state,
         metadata=metadata,
+        strategy=strategy_payload,
     )
 
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
@@ -287,6 +293,17 @@ def _render_export_import_panel() -> None:
                 st.session_state["finance_settings"] = settings_state
             if pending_payload.get("metadata"):
                 st.session_state["industry_template_state"] = pending_payload["metadata"]
+            if pending_payload.get("strategy"):
+                strategy_data = pending_payload["strategy"]
+                st.session_state["strategy_bsc"] = strategy.normalize_bsc_state(
+                    strategy_data.get("bsc")
+                )
+                st.session_state["strategy_pest"] = strategy.normalize_pest_state(
+                    strategy_data.get("pest")
+                )
+                st.session_state["strategy_swot"] = strategy.normalize_swot_state(
+                    strategy_data.get("swot")
+                )
             st.session_state[IMPORT_MESSAGE_KEY] = {
                 "filename": filename,
                 "warnings": warnings,

--- a/pages/7_戦略フレームワーク設定.py
+++ b/pages/7_戦略フレームワーク設定.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+from typing import Dict
+
+import pandas as pd
+import streamlit as st
+
+from core import strategy
+from localization import render_language_status_alert, translate
+from state import load_finance_bundle
+
+
+def _current_display_settings() -> tuple[str, str]:
+    settings: Dict[str, object] = dict(st.session_state.get("finance_settings", {}))
+    unit = str(settings.get("unit", "百万円"))
+    currency = str(settings.get("currency", "JPY"))
+    return unit, currency
+
+
+def _render_bsc_tab() -> None:
+    st.markdown(
+        "財務・顧客・内部プロセス・学習成長の4視点で、目標・指標・ターゲットを整理します。"
+        "ここで保存した内容はダッシュボードとレポート出力に反映されます。"
+    )
+
+    current_state = strategy.normalize_bsc_state(st.session_state.get("strategy_bsc", {}))
+    updated_state: Dict[str, list[dict[str, str]]] = {}
+    with st.form("strategy_bsc_form"):
+        for key, label in strategy.BSC_PERSPECTIVES:
+            st.markdown(f"#### {label}視点")
+            rows = [
+                {
+                    "目標": entry.get("objective", ""),
+                    "指標": entry.get("metric", ""),
+                    "ターゲット": entry.get("target", ""),
+                }
+                for entry in current_state.get(key, [])
+            ]
+            if not rows:
+                rows = [{"目標": "", "指標": "", "ターゲット": ""}]
+            edited = st.data_editor(
+                pd.DataFrame(rows),
+                num_rows="dynamic",
+                use_container_width=True,
+                hide_index=True,
+                key=f"strategy_bsc_editor_{key}",
+            )
+            if isinstance(edited, pd.DataFrame):
+                records = edited.to_dict(orient="records")
+            else:
+                records = list(edited)
+            cleaned: list[dict[str, str]] = []
+            for row in records:
+                objective = str(row.get("目標", "")).strip()
+                metric = str(row.get("指標", "")).strip()
+                target = str(row.get("ターゲット", "")).strip()
+                if not any([objective, metric, target]):
+                    continue
+                cleaned.append({
+                    "objective": objective,
+                    "metric": metric,
+                    "target": target,
+                })
+            updated_state[key] = cleaned
+        submitted = st.form_submit_button("BSC設定を保存")
+
+    if submitted:
+        st.session_state["strategy_bsc"] = updated_state
+        st.success("BSC設定を保存しました。")
+
+    preview = strategy.build_bsc_display_frame(st.session_state.get("strategy_bsc", {}))
+    if not preview.empty:
+        st.markdown("#### 登録済みBSCサマリー")
+        st.dataframe(preview, use_container_width=True, hide_index=True)
+    else:
+        st.info("各視点の行を追加するとダッシュボードにカードが表示されます。")
+
+
+def _render_pest_tab() -> None:
+    st.markdown(
+        "政治・経済・社会・技術の外部環境を整理し、リスクと機会の仮説を明確化します。"
+        "入力した内容はSWOT分析やレポートのリスク評価で参照されます。"
+    )
+    current_state = strategy.normalize_pest_state(st.session_state.get("strategy_pest", {}))
+    inputs: Dict[str, str] = {}
+    with st.form("strategy_pest_form"):
+        for key, label, hint in strategy.PEST_DIMENSIONS:
+            default_text = "\n".join(current_state.get(key, []))
+            inputs[key] = st.text_area(
+                f"{label}要因 ({hint})",
+                value=default_text,
+                height=120,
+                placeholder="箇条書きで入力してください",
+                key=f"strategy_pest_input_{key}",
+            )
+        submitted = st.form_submit_button("外部環境分析を保存")
+
+    if submitted:
+        updated = {
+            key: [line.strip() for line in inputs.get(key, "").splitlines() if line.strip()]
+            for key in current_state.keys()
+        }
+        st.session_state["strategy_pest"] = updated
+        st.success("PEST分析を保存しました。")
+
+    display_map = strategy.build_pest_display(st.session_state.get("strategy_pest", {}))
+    st.markdown("#### 登録済み外部環境要因")
+    for label, entries in display_map.items():
+        st.markdown(f"**{label}**")
+        if entries:
+            for entry in entries:
+                st.markdown(f"- {entry}")
+        else:
+            st.caption("未入力です。")
+
+
+def _render_swot_tab(unit: str, currency: str) -> None:
+    st.markdown(
+        "内部資源と外部要因を組み合わせ、強み・弱み・機会・脅威を整理します。"
+        "入力値に応じてAIが財務データやPESTの内容をもとに提案を表示します。"
+    )
+
+    current_state = strategy.normalize_swot_state(st.session_state.get("strategy_swot", {}))
+    inputs: Dict[str, str] = {}
+    with st.form("strategy_swot_form"):
+        for key, label in strategy.SWOT_CATEGORIES:
+            default_text = "\n".join(current_state.get(key, []))
+            inputs[key] = st.text_area(
+                f"{label}",
+                value=default_text,
+                height=140,
+                placeholder=f"{label}に該当する要素を箇条書きで入力",
+                key=f"strategy_swot_input_{key}",
+            )
+        submitted = st.form_submit_button("SWOT分析を保存")
+
+    if submitted:
+        updated = {
+            key: [line.strip() for line in inputs.get(key, "").splitlines() if line.strip()]
+            for key in current_state.keys()
+        }
+        st.session_state["strategy_swot"] = updated
+        st.success("SWOT分析を保存しました。")
+
+    swot_display = strategy.build_swot_display(st.session_state.get("strategy_swot", {}))
+    cols = st.columns(2)
+    for index, (label, entries) in enumerate(swot_display.items()):
+        column = cols[index % 2]
+        with column:
+            st.markdown(f"#### {label}")
+            if entries:
+                for entry in entries:
+                    st.markdown(f"- {entry}")
+            else:
+                st.caption("未入力です。")
+
+    bundle, _ = load_finance_bundle()
+    finance_summary = strategy.summarize_financial_context(bundle)
+    suggestions = strategy.generate_swot_suggestions(
+        st.session_state.get("strategy_swot", {}),
+        st.session_state.get("strategy_pest", {}),
+        finance_summary,
+        unit=unit,
+        currency=currency,
+        bsc_state=st.session_state.get("strategy_bsc", {}),
+    )
+
+    st.markdown("#### AIサポートコメント")
+    if suggestions:
+        for suggestion in suggestions:
+            st.markdown(f"- {suggestion}")
+    else:
+        st.info("PESTや財務データを入力するとサポートコメントが表示されます。")
+
+
+def main() -> None:
+    render_language_status_alert()
+    st.title(translate("pages.strategy.title"))
+    st.caption(translate("pages.strategy.caption"))
+
+    unit, currency = _current_display_settings()
+
+    bsc_tab, pest_tab, swot_tab = st.tabs(["BSC設定", "外部環境分析", "SWOT分析"])
+
+    with bsc_tab:
+        _render_bsc_tab()
+    with pest_tab:
+        _render_pest_tab()
+    with swot_tab:
+        _render_swot_tab(unit, currency)
+
+
+if __name__ == "__main__":
+    main()

--- a/state.py
+++ b/state.py
@@ -83,6 +83,36 @@ STATE_SPECS: Dict[str, StateSpec] = {
     ),
     "state_backups": StateSpec(list, list, "セッションスナップショット"),
     "industry_template_state": StateSpec(dict, dict, "業種テンプレート設定"),
+    "strategy_bsc": StateSpec(
+        lambda: {
+            "financial": [],
+            "customer": [],
+            "process": [],
+            "learning": [],
+        },
+        dict,
+        "BSC設定",
+    ),
+    "strategy_pest": StateSpec(
+        lambda: {
+            "political": [],
+            "economic": [],
+            "social": [],
+            "technological": [],
+        },
+        dict,
+        "PEST分析入力",
+    ),
+    "strategy_swot": StateSpec(
+        lambda: {
+            "strengths": [],
+            "weaknesses": [],
+            "opportunities": [],
+            "threats": [],
+        },
+        dict,
+        "SWOT分析入力",
+    ),
 }
 
 


### PR DESCRIPTION
## Summary
- add a dedicated strategy configuration page with BSC, PEST and SWOT editors plus AI-style guidance
- persist strategy inputs in session state, surface them on the dashboard and include them in export/import payloads
- update navigation labels and translations for the new strategy workflows

## Testing
- python -m compileall core pages state.py app.py

------
https://chatgpt.com/codex/tasks/task_e_68cfc6925a7c832394733ecb62d0787d